### PR TITLE
style: 코드 블럭의 font color 및 배경색 변경

### DIFF
--- a/components/PostDetail.tsx
+++ b/components/PostDetail.tsx
@@ -55,8 +55,8 @@ export const PostDetail: React.FC<PostDetailProps> = ({ post }) => {
       <div className="prose prose-lg prose-slate dark:prose-invert max-w-none 
         prose-headings:font-bold prose-headings:tracking-tight 
         prose-a:text-indigo-600 dark:prose-a:text-indigo-400 prose-a:no-underline hover:prose-a:underline
-        prose-code:text-indigo-600 dark:prose-code:text-indigo-300 prose-code:bg-indigo-50 dark:prose-code:bg-indigo-950/30 prose-code:px-1 prose-code:rounded prose-code:font-normal prose-code:before:content-none prose-code:after:content-none
-        prose-pre:bg-slate-900 dark:prose-pre:bg-slate-900 prose-pre:border prose-pre:border-slate-800
+        prose-code:text-gray-900 dark:prose-code:text-white prose-code:font-normal prose-code:before:content-none prose-code:after:content-none
+        prose-pre:bg-slate-900 dark:prose-pre:bg-slate-900 prose-pre:text-white dark:prose-pre:text-white [&_pre_code]:text-white dark:[&_pre_code]:text-white prose-pre:border prose-pre:border-slate-800
         prose-img:rounded-xl prose-img:shadow-lg">
         <MDXRemote source={post.content} />
       </div>


### PR DESCRIPTION
### 작업 내용

   1. 코드 블록 스타일 간소화
       * 신택스 하이라이팅을 제거하고, 검은 배경(`bg-slate-900`)에 흰색 텍스트로 통일
       * 라이트 모드에서 코드 블록 텍스트가 어두운 회색으로 변해 배경에 묻히는 문제를 해결하기 위해, pre 태그 내부의 code 텍스트를
         흰색([&_pre_code]:text-white)으로 고정

   2. 인라인 코드 하이라이트 제거
       * 인라인 코드(prose-code)에 적용되던 배경색(bg-indigo-50)과 패딩을 제거