### PR TITLE
feat: add db-backed draft studio and pipeline integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/jeanne_log
+INTERNAL_API_TOKEN=replace-me

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/jeanne_log
 INTERNAL_API_TOKEN=replace-me
 NEXT_PUBLIC_GA_ID=
+ADMIN_PASSWORD=replace-with-admin-password
+ADMIN_SESSION_SECRET=replace-with-a-long-random-secret-at-least-32-chars

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/jeanne_log
 INTERNAL_API_TOKEN=replace-me
+NEXT_PUBLIC_GA_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 dist-ssr
 .next/
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/app/api/admin/comments/[id]/route.ts
+++ b/app/api/admin/comments/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { assertAdminRequest } from "@/lib/auth/admin-session";
 import { deleteComment, updateComment } from "@/services/commentRepository";
 import { updateCommentSchema } from "@/lib/validators/comments";
 
@@ -10,6 +11,7 @@ type RouteProps = {
 
 export async function PATCH(request: NextRequest, { params }: RouteProps) {
   try {
+    await assertAdminRequest(request);
     const { id } = await params;
     const body = await request.json();
     const parsed = updateCommentSchema.safeParse(body);
@@ -49,13 +51,14 @@ export async function PATCH(request: NextRequest, { params }: RouteProps) {
         ok: false,
         error: message,
       },
-      { status: 500 }
+      { status: message.includes("Admin session") ? 401 : 500 }
     );
   }
 }
 
 export async function DELETE(_: NextRequest, { params }: RouteProps) {
   try {
+    await assertAdminRequest(_);
     const { id } = await params;
     const deleted = await deleteComment(id);
 
@@ -80,7 +83,7 @@ export async function DELETE(_: NextRequest, { params }: RouteProps) {
         ok: false,
         error: message,
       },
-      { status: 500 }
+      { status: message.includes("Admin session") ? 401 : 500 }
     );
   }
 }

--- a/app/api/admin/comments/[id]/route.ts
+++ b/app/api/admin/comments/[id]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { deleteComment, updateComment } from "@/services/commentRepository";
+import { updateCommentSchema } from "@/lib/validators/comments";
+
+type RouteProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function PATCH(request: NextRequest, { params }: RouteProps) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = updateCommentSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Invalid comment update payload.",
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const comment = await updateComment(id, parsed.data);
+
+    if (!comment) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Comment not found.",
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      comment,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(_: NextRequest, { params }: RouteProps) {
+  try {
+    const { id } = await params;
+    const deleted = await deleteComment(id);
+
+    if (!deleted) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Comment not found.",
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/comments/route.ts
+++ b/app/api/admin/comments/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
+import { assertAdminRequest } from "@/lib/auth/admin-session";
 import { createComment } from "@/services/commentRepository";
 import { createCommentSchema } from "@/lib/validators/comments";
 
 export async function POST(request: NextRequest) {
   try {
+    await assertAdminRequest(request);
     const body = await request.json();
     const parsed = createCommentSchema.safeParse(body);
 
@@ -29,8 +31,11 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    const status =
-      message.includes("not found") || message.includes("exceeds available lines") ? 400 : 500;
+    const status = message.includes("Admin session")
+      ? 401
+      : message.includes("not found") || message.includes("exceeds available lines")
+        ? 400
+        : 500;
 
     return NextResponse.json(
       {

--- a/app/api/admin/comments/route.ts
+++ b/app/api/admin/comments/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createComment } from "@/services/commentRepository";
+import { createCommentSchema } from "@/lib/validators/comments";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = createCommentSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Invalid comment payload.",
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const comment = await createComment(parsed.data);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        comment,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const status =
+      message.includes("not found") || message.includes("exceeds available lines") ? 400 : 500;
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/app/api/admin/drafts/[id]/regenerate/route.ts
+++ b/app/api/admin/drafts/[id]/regenerate/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRegenerationJob } from "@/services/regenerationJobRepository";
+
+type RouteProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function POST(_: NextRequest, { params }: RouteProps) {
+  try {
+    const { id } = await params;
+    const job = await createRegenerationJob(id);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        jobId: job.id,
+        status: job.status,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const status = message.includes("queued or running")
+      ? 409
+      : message.includes("not found") || message.includes("no current version")
+        ? 404
+        : 500;
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/app/api/admin/drafts/[id]/regenerate/route.ts
+++ b/app/api/admin/drafts/[id]/regenerate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { assertAdminRequest } from "@/lib/auth/admin-session";
 import { createRegenerationJob } from "@/services/regenerationJobRepository";
 
 type RouteProps = {
@@ -9,6 +10,7 @@ type RouteProps = {
 
 export async function POST(_: NextRequest, { params }: RouteProps) {
   try {
+    await assertAdminRequest(_);
     const { id } = await params;
     const job = await createRegenerationJob(id);
 
@@ -22,11 +24,13 @@ export async function POST(_: NextRequest, { params }: RouteProps) {
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    const status = message.includes("queued or running")
-      ? 409
-      : message.includes("not found") || message.includes("no current version")
-        ? 404
-        : 500;
+    const status = message.includes("Admin session")
+      ? 401
+      : message.includes("queued or running")
+        ? 409
+        : message.includes("not found") || message.includes("no current version")
+          ? 404
+          : 500;
 
     return NextResponse.json(
       {

--- a/app/api/admin/drafts/[id]/route.ts
+++ b/app/api/admin/drafts/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/db/client";
+import { createManualDraftVersion } from "@/lib/content/drafts";
+import { updateDraftSchema } from "@/lib/validators/drafts";
+
+type RouteProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function PATCH(request: NextRequest, { params }: RouteProps) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = updateDraftSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Invalid draft update payload.",
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const result = await createManualDraftVersion(getDb(), id, parsed.data);
+
+    return NextResponse.json({
+      ok: true,
+      articleId: result.articleId,
+      versionId: result.versionId,
+      versionNumber: result.versionNumber,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const status = message.includes("not found") ? 404 : 500;
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/app/api/admin/drafts/[id]/route.ts
+++ b/app/api/admin/drafts/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { assertAdminRequest } from "@/lib/auth/admin-session";
 import { getDb } from "@/db/client";
 import { createManualDraftVersion } from "@/lib/content/drafts";
 import { updateDraftSchema } from "@/lib/validators/drafts";
@@ -11,6 +12,7 @@ type RouteProps = {
 
 export async function PATCH(request: NextRequest, { params }: RouteProps) {
   try {
+    await assertAdminRequest(request);
     const { id } = await params;
     const body = await request.json();
     const parsed = updateDraftSchema.safeParse(body);
@@ -36,7 +38,11 @@ export async function PATCH(request: NextRequest, { params }: RouteProps) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    const status = message.includes("not found") ? 404 : 500;
+    const status = message.includes("Admin session")
+      ? 401
+      : message.includes("not found")
+        ? 404
+        : 500;
 
     return NextResponse.json(
       {

--- a/app/api/auth/admin/login/route.ts
+++ b/app/api/auth/admin/login/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createAdminSessionCookie,
+  verifyAdminPassword,
+} from "@/lib/auth/admin-session";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const password = typeof body.password === "string" ? body.password : "";
+
+    if (!password) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Password is required.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!verifyAdminPassword(password)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Invalid password.",
+        },
+        { status: 401 }
+      );
+    }
+
+    const sessionCookie = await createAdminSessionCookie();
+    const response = NextResponse.json({
+      ok: true,
+    });
+
+    response.cookies.set(
+      sessionCookie.name,
+      sessionCookie.value,
+      sessionCookie.options
+    );
+
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/admin/logout/route.ts
+++ b/app/api/auth/admin/logout/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { clearAdminSessionCookie } from "@/lib/auth/admin-session";
+
+export async function POST() {
+  const sessionCookie = clearAdminSessionCookie();
+  const response = NextResponse.json({
+    ok: true,
+  });
+
+  response.cookies.set(
+    sessionCookie.name,
+    sessionCookie.value,
+    sessionCookie.options
+  );
+
+  return response;
+}

--- a/app/api/internal/drafts/route.ts
+++ b/app/api/internal/drafts/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/db/client";
+import { assertInternalRequest } from "@/lib/api/internal";
+import { createOrUpdateDraft } from "@/lib/content/drafts";
+import { internalDraftSchema } from "@/lib/validators/internal-drafts";
+
+export async function POST(request: NextRequest) {
+  try {
+    assertInternalRequest(request);
+
+    const body = await request.json();
+    const parsed = internalDraftSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid draft payload.",
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const result = await createOrUpdateDraft(getDb(), parsed.data);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        articleId: result.articleId,
+        versionId: result.versionId,
+        versionNumber: result.versionNumber,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    let status = 500;
+
+    if (message.includes("Missing bearer token") || message.includes("Invalid internal API token")) {
+      status = 401;
+    } else if (message.includes("published article")) {
+      status = 409;
+    }
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/app/api/internal/jobs/[id]/complete/route.ts
+++ b/app/api/internal/jobs/[id]/complete/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { assertInternalRequest, getInternalWorkerId } from "@/lib/api/internal";
+import { completeRegenerationJob } from "@/services/regenerationJobRepository";
+import { completeRegenerationJobSchema } from "@/lib/validators/internal-jobs";
+
+type RouteProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function POST(request: NextRequest, { params }: RouteProps) {
+  try {
+    assertInternalRequest(request);
+    const workerId = getInternalWorkerId(request);
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = completeRegenerationJobSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Invalid completion payload.",
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const job = await completeRegenerationJob(id, workerId, parsed.data);
+
+    return NextResponse.json({
+      ok: true,
+      job,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const status =
+      message.includes("Missing bearer token") ||
+      message.includes("Invalid internal API token") ||
+      message.includes("Missing worker id")
+        ? 401
+        : message.includes("not found")
+          ? 404
+          : message.includes("not running") || message.includes("another worker")
+            ? 409
+            : 500;
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/app/api/internal/jobs/[id]/fail/route.ts
+++ b/app/api/internal/jobs/[id]/fail/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { assertInternalRequest, getInternalWorkerId } from "@/lib/api/internal";
+import { failRegenerationJob } from "@/services/regenerationJobRepository";
+import { failRegenerationJobSchema } from "@/lib/validators/internal-jobs";
+
+type RouteProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function POST(request: NextRequest, { params }: RouteProps) {
+  try {
+    assertInternalRequest(request);
+    const workerId = getInternalWorkerId(request);
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = failRegenerationJobSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Invalid failure payload.",
+          issues: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const job = await failRegenerationJob(id, workerId, parsed.data);
+
+    return NextResponse.json({
+      ok: true,
+      job,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const status =
+      message.includes("Missing bearer token") ||
+      message.includes("Invalid internal API token") ||
+      message.includes("Missing worker id")
+        ? 401
+        : message.includes("not found")
+          ? 404
+          : message.includes("not running") || message.includes("another worker")
+            ? 409
+            : 500;
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/app/api/internal/jobs/next/route.ts
+++ b/app/api/internal/jobs/next/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { assertInternalRequest, getInternalWorkerId } from "@/lib/api/internal";
+import { claimNextRegenerationJob } from "@/services/regenerationJobRepository";
+
+export async function GET(request: NextRequest) {
+  try {
+    assertInternalRequest(request);
+    const workerId = getInternalWorkerId(request);
+    const type = request.nextUrl.searchParams.get("type");
+
+    if (type && type !== "regenerate") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Unsupported job type.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const job = await claimNextRegenerationJob(workerId);
+
+    return NextResponse.json({
+      ok: true,
+      job,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    const status =
+      message.includes("Missing bearer token") ||
+      message.includes("Invalid internal API token") ||
+      message.includes("Missing worker id")
+        ? 401
+        : 500;
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/app/studio/drafts/[id]/page.tsx
+++ b/app/studio/drafts/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { DraftEditor } from "@/components/studio/DraftEditor";
 import { getDraftDetailById } from "@/services/draftRepository";
 
 const statusStyles: Record<string, string> = {
@@ -89,50 +90,60 @@ export default async function DraftDetailPage({ params }: Props) {
       </div>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.9fr)]">
-        <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950">
-          <header className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
-              Current Source
-            </h2>
-          </header>
+        <div className="grid gap-6">
+          <DraftEditor
+            key={draft.currentVersionId ?? "empty-version"}
+            draftId={draft.id}
+            initialTitle={draft.title}
+            initialSummary={draft.summary}
+            initialContent={draft.content}
+          />
 
-          {draft.lineIndex.length === 0 ? (
-            <div className="px-5 py-8 text-sm text-slate-500 dark:text-slate-400">
-              아직 버전 콘텐츠가 없습니다.
-            </div>
-          ) : (
-            <div className="max-h-[70vh] overflow-auto">
-              <ol className="divide-y divide-slate-100 dark:divide-slate-900">
-                {draft.lineIndex.map((line) => {
-                  const commentsForLine = draft.comments.filter(
-                    (comment) =>
-                      comment.status === "open" &&
-                      line.lineNumber >= comment.startLine &&
-                      line.lineNumber <= comment.endLine
-                  );
+          <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950">
+            <header className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Current Source
+              </h2>
+            </header>
 
-                  return (
-                    <li
-                      key={`${line.lineNumber}-${line.startOffset}`}
-                      className={`grid grid-cols-[72px_minmax(0,1fr)] gap-4 px-5 py-2 font-mono text-sm ${
-                        commentsForLine.length > 0
-                          ? "bg-amber-50/80 dark:bg-amber-500/10"
-                          : "bg-transparent"
-                      }`}
-                    >
-                      <span className="select-none text-right text-xs leading-6 text-slate-400">
-                        {line.lineNumber}
-                      </span>
-                      <pre className="overflow-x-auto whitespace-pre-wrap break-words leading-6 text-slate-700 dark:text-slate-200">
-                        {line.content || " "}
-                      </pre>
-                    </li>
-                  );
-                })}
-              </ol>
-            </div>
-          )}
-        </section>
+            {draft.lineIndex.length === 0 ? (
+              <div className="px-5 py-8 text-sm text-slate-500 dark:text-slate-400">
+                아직 버전 콘텐츠가 없습니다.
+              </div>
+            ) : (
+              <div className="max-h-[70vh] overflow-auto">
+                <ol className="divide-y divide-slate-100 dark:divide-slate-900">
+                  {draft.lineIndex.map((line) => {
+                    const commentsForLine = draft.comments.filter(
+                      (comment) =>
+                        comment.status === "open" &&
+                        line.lineNumber >= comment.startLine &&
+                        line.lineNumber <= comment.endLine
+                    );
+
+                    return (
+                      <li
+                        key={`${line.lineNumber}-${line.startOffset}`}
+                        className={`grid grid-cols-[72px_minmax(0,1fr)] gap-4 px-5 py-2 font-mono text-sm ${
+                          commentsForLine.length > 0
+                            ? "bg-amber-50/80 dark:bg-amber-500/10"
+                            : "bg-transparent"
+                        }`}
+                      >
+                        <span className="select-none text-right text-xs leading-6 text-slate-400">
+                          {line.lineNumber}
+                        </span>
+                        <pre className="overflow-x-auto whitespace-pre-wrap break-words leading-6 text-slate-700 dark:text-slate-200">
+                          {line.content || " "}
+                        </pre>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </div>
+            )}
+          </section>
+        </div>
 
         <div className="grid gap-6">
           <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">

--- a/app/studio/drafts/[id]/page.tsx
+++ b/app/studio/drafts/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { CommentManager } from "@/components/studio/CommentManager";
 import { DraftEditor } from "@/components/studio/DraftEditor";
 import { RegenerateDraftButton } from "@/components/studio/RegenerateDraftButton";
+import { StudioLogoutButton } from "@/components/studio/StudioLogoutButton";
 import { getDraftDetailById } from "@/services/draftRepository";
 
 const statusStyles: Record<string, string> = {
@@ -39,14 +40,17 @@ export default async function DraftDetailPage({ params }: Props) {
 
   return (
     <section className="space-y-8">
-      <div className="flex flex-wrap items-center justify-between gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="space-y-3">
-          <Link
-            href="/studio/drafts"
-            className="inline-flex items-center text-sm font-medium text-slate-500 transition-colors hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
-          >
-            Back to Drafts
-          </Link>
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              href="/studio/drafts"
+              className="inline-flex items-center text-sm font-medium text-slate-500 transition-colors hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+            >
+              Back to Drafts
+            </Link>
+            <StudioLogoutButton />
+          </div>
           <div className="space-y-2">
             <div className="flex flex-wrap items-center gap-2">
               <span

--- a/app/studio/drafts/[id]/page.tsx
+++ b/app/studio/drafts/[id]/page.tsx
@@ -1,0 +1,216 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getDraftDetailById } from "@/services/draftRepository";
+
+const statusStyles: Record<string, string> = {
+  draft: "bg-amber-100 text-amber-900",
+  in_review: "bg-blue-100 text-blue-900",
+  regenerating: "bg-violet-100 text-violet-900",
+  published: "bg-emerald-100 text-emerald-900",
+  archived: "bg-slate-200 text-slate-700",
+};
+
+const statusLabels: Record<string, string> = {
+  draft: "Draft",
+  in_review: "In Review",
+  regenerating: "Regenerating",
+  published: "Published",
+  archived: "Archived",
+};
+
+type Props = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export default async function DraftDetailPage({ params }: Props) {
+  const { id } = await params;
+  const draft = await getDraftDetailById(id);
+
+  if (!draft) {
+    notFound();
+  }
+
+  return (
+    <section className="space-y-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-3">
+          <Link
+            href="/studio/drafts"
+            className="inline-flex items-center text-sm font-medium text-slate-500 transition-colors hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+          >
+            Back to Drafts
+          </Link>
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${statusStyles[draft.status]}`}
+              >
+                {statusLabels[draft.status]}
+              </span>
+              <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-400">
+                {draft.slug}
+              </span>
+            </div>
+            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+              {draft.title}
+            </h1>
+            <p className="max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+              {draft.summary || "요약이 아직 없습니다."}
+            </p>
+          </div>
+        </div>
+
+        <dl className="grid grid-cols-2 gap-3 rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-900/80">
+          <div>
+            <dt className="text-slate-400">Current Version</dt>
+            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+              {draft.currentVersionNumber ?? "-"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-400">Open Comments</dt>
+            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+              {draft.comments.filter((comment) => comment.status === "open").length}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-400">Versions</dt>
+            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">{draft.versions.length}</dd>
+          </div>
+          <div>
+            <dt className="text-slate-400">Updated</dt>
+            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+              {new Date(draft.updatedAt).toLocaleString("ko-KR")}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.9fr)]">
+        <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950">
+          <header className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Current Source
+            </h2>
+          </header>
+
+          {draft.lineIndex.length === 0 ? (
+            <div className="px-5 py-8 text-sm text-slate-500 dark:text-slate-400">
+              아직 버전 콘텐츠가 없습니다.
+            </div>
+          ) : (
+            <div className="max-h-[70vh] overflow-auto">
+              <ol className="divide-y divide-slate-100 dark:divide-slate-900">
+                {draft.lineIndex.map((line) => {
+                  const commentsForLine = draft.comments.filter(
+                    (comment) =>
+                      comment.status === "open" &&
+                      line.lineNumber >= comment.startLine &&
+                      line.lineNumber <= comment.endLine
+                  );
+
+                  return (
+                    <li
+                      key={`${line.lineNumber}-${line.startOffset}`}
+                      className={`grid grid-cols-[72px_minmax(0,1fr)] gap-4 px-5 py-2 font-mono text-sm ${
+                        commentsForLine.length > 0
+                          ? "bg-amber-50/80 dark:bg-amber-500/10"
+                          : "bg-transparent"
+                      }`}
+                    >
+                      <span className="select-none text-right text-xs leading-6 text-slate-400">
+                        {line.lineNumber}
+                      </span>
+                      <pre className="overflow-x-auto whitespace-pre-wrap break-words leading-6 text-slate-700 dark:text-slate-200">
+                        {line.content || " "}
+                      </pre>
+                    </li>
+                  );
+                })}
+              </ol>
+            </div>
+          )}
+        </section>
+
+        <div className="grid gap-6">
+          <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+            <header className="mb-4 flex items-center justify-between">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Versions
+              </h2>
+              <span className="text-xs text-slate-400">Latest first</span>
+            </header>
+
+            <div className="space-y-3">
+              {draft.versions.map((version) => (
+                <article
+                  key={version.id}
+                  className={`rounded-2xl border px-4 py-3 ${
+                    version.id === draft.currentVersionId
+                      ? "border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-950"
+                      : "border-slate-200 bg-slate-50 text-slate-900 dark:border-slate-800 dark:bg-slate-900 dark:text-white"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <strong className="text-sm">v{version.versionNumber}</strong>
+                    <span className="text-xs uppercase tracking-[0.15em] opacity-70">
+                      {version.sourceType}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs opacity-80">
+                    {version.sourceLabel || version.modelName || "Source metadata unavailable"}
+                  </p>
+                  <p className="mt-2 text-xs opacity-60">
+                    {new Date(version.createdAt).toLocaleString("ko-KR")}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+            <header className="mb-4 flex items-center justify-between">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Comments
+              </h2>
+              <span className="text-xs text-slate-400">{draft.comments.length} items</span>
+            </header>
+
+            {draft.comments.length === 0 ? (
+              <p className="text-sm leading-6 text-slate-500 dark:text-slate-400">
+                아직 코멘트가 없습니다. 다음 단계에서 인라인 코멘트 작성과 수정/삭제 기능이 추가됩니다.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {draft.comments.map((comment) => (
+                  <article
+                    key={comment.id}
+                    className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                        L{comment.startLine}
+                        {comment.startLine !== comment.endLine ? `-L${comment.endLine}` : ""}
+                      </span>
+                      <span className="rounded-full bg-slate-200 px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                        {comment.status}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">
+                      {comment.body}
+                    </p>
+                    <pre className="mt-3 overflow-x-auto rounded-xl bg-white px-3 py-2 font-mono text-xs leading-5 text-slate-500 dark:bg-slate-950 dark:text-slate-400">
+                      {comment.selectedText}
+                    </pre>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/studio/drafts/[id]/page.tsx
+++ b/app/studio/drafts/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { DraftEditor } from "@/components/studio/DraftEditor";
+import { RegenerateDraftButton } from "@/components/studio/RegenerateDraftButton";
 import { getDraftDetailById } from "@/services/draftRepository";
 
 const statusStyles: Record<string, string> = {
@@ -33,6 +34,8 @@ export default async function DraftDetailPage({ params }: Props) {
     notFound();
   }
 
+  const openCommentCount = draft.comments.filter((comment) => comment.status === "open").length;
+
   return (
     <section className="space-y-8">
       <div className="flex flex-wrap items-center justify-between gap-4">
@@ -63,31 +66,43 @@ export default async function DraftDetailPage({ params }: Props) {
           </div>
         </div>
 
-        <dl className="grid grid-cols-2 gap-3 rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-900/80">
-          <div>
-            <dt className="text-slate-400">Current Version</dt>
-            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
-              {draft.currentVersionNumber ?? "-"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-slate-400">Open Comments</dt>
-            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
-              {draft.comments.filter((comment) => comment.status === "open").length}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-slate-400">Versions</dt>
-            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">{draft.versions.length}</dd>
-          </div>
-          <div>
-            <dt className="text-slate-400">Updated</dt>
-            <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
-              {new Date(draft.updatedAt).toLocaleString("ko-KR")}
-            </dd>
-          </div>
-        </dl>
+        <div className="grid gap-3">
+          <RegenerateDraftButton
+            draftId={draft.id}
+            openCommentCount={openCommentCount}
+            disabled={!draft.currentVersionId || draft.status === "regenerating"}
+          />
+
+          <dl className="grid grid-cols-2 gap-3 rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-900/80">
+            <div>
+              <dt className="text-slate-400">Current Version</dt>
+              <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+                {draft.currentVersionNumber ?? "-"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-slate-400">Open Comments</dt>
+              <dd className="mt-1 font-semibold text-slate-900 dark:text-white">{openCommentCount}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-400">Versions</dt>
+              <dd className="mt-1 font-semibold text-slate-900 dark:text-white">{draft.versions.length}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-400">Updated</dt>
+              <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+                {new Date(draft.updatedAt).toLocaleString("ko-KR")}
+              </dd>
+            </div>
+          </dl>
+        </div>
       </div>
+
+      {draft.status === "regenerating" ? (
+        <div className="rounded-2xl border border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-900 dark:border-violet-900/60 dark:bg-violet-500/10 dark:text-violet-200">
+          A regeneration job is currently queued or running for this draft.
+        </div>
+      ) : null}
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.9fr)]">
         <div className="grid gap-6">

--- a/app/studio/drafts/[id]/page.tsx
+++ b/app/studio/drafts/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { CommentManager } from "@/components/studio/CommentManager";
 import { DraftEditor } from "@/components/studio/DraftEditor";
 import { RegenerateDraftButton } from "@/components/studio/RegenerateDraftButton";
 import { getDraftDetailById } from "@/services/draftRepository";
@@ -196,45 +197,11 @@ export default async function DraftDetailPage({ params }: Props) {
             </div>
           </section>
 
-          <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
-            <header className="mb-4 flex items-center justify-between">
-              <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
-                Comments
-              </h2>
-              <span className="text-xs text-slate-400">{draft.comments.length} items</span>
-            </header>
-
-            {draft.comments.length === 0 ? (
-              <p className="text-sm leading-6 text-slate-500 dark:text-slate-400">
-                아직 코멘트가 없습니다. 다음 단계에서 인라인 코멘트 작성과 수정/삭제 기능이 추가됩니다.
-              </p>
-            ) : (
-              <div className="space-y-3">
-                {draft.comments.map((comment) => (
-                  <article
-                    key={comment.id}
-                    className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900"
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
-                        L{comment.startLine}
-                        {comment.startLine !== comment.endLine ? `-L${comment.endLine}` : ""}
-                      </span>
-                      <span className="rounded-full bg-slate-200 px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-slate-700 dark:bg-slate-800 dark:text-slate-300">
-                        {comment.status}
-                      </span>
-                    </div>
-                    <p className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">
-                      {comment.body}
-                    </p>
-                    <pre className="mt-3 overflow-x-auto rounded-xl bg-white px-3 py-2 font-mono text-xs leading-5 text-slate-500 dark:bg-slate-950 dark:text-slate-400">
-                      {comment.selectedText}
-                    </pre>
-                  </article>
-                ))}
-              </div>
-            )}
-          </section>
+          <CommentManager
+            articleVersionId={draft.currentVersionId}
+            lineCount={draft.lineIndex.length}
+            initialComments={draft.comments}
+          />
         </div>
       </div>
     </section>

--- a/app/studio/drafts/page.tsx
+++ b/app/studio/drafts/page.tsx
@@ -1,0 +1,103 @@
+import { getDraftSummaries } from "@/services/draftRepository";
+
+const statusStyles: Record<string, string> = {
+  draft: "bg-amber-100 text-amber-900",
+  in_review: "bg-blue-100 text-blue-900",
+  regenerating: "bg-violet-100 text-violet-900",
+  published: "bg-emerald-100 text-emerald-900",
+  archived: "bg-slate-200 text-slate-700",
+};
+
+const statusLabels: Record<string, string> = {
+  draft: "Draft",
+  in_review: "In Review",
+  regenerating: "Regenerating",
+  published: "Published",
+  archived: "Archived",
+};
+
+export default async function DraftStudioPage() {
+  const drafts = await getDraftSummaries();
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-3">
+        <span className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white">
+          Studio
+        </span>
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            Draft Queue
+          </h1>
+          <p className="max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+            DB에 적재된 초안과 현재 리뷰 상태를 확인하는 화면입니다. 상세 리뷰와 인증은 다음 단계에서
+            이어집니다.
+          </p>
+        </div>
+      </header>
+
+      {drafts.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-slate-300 bg-slate-50 px-6 py-12 text-center dark:border-slate-700 dark:bg-slate-900/60">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">No drafts yet</h2>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+            아직 DB에 적재된 초안이 없습니다. `db:import:legacy` 또는 내부 draft API로 데이터를 먼저
+            넣어야 합니다.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {drafts.map((draft) => (
+            <article
+              key={draft.id}
+              className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-800 dark:bg-slate-950"
+            >
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="space-y-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${statusStyles[draft.status]}`}
+                    >
+                      {statusLabels[draft.status]}
+                    </span>
+                    <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-400">
+                      {draft.slug}
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+                      {draft.title}
+                    </h2>
+                    <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
+                      {draft.summary || "요약이 아직 없습니다."}
+                    </p>
+                  </div>
+                </div>
+
+                <dl className="grid grid-cols-3 gap-3 rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-900/80">
+                  <div>
+                    <dt className="text-slate-400">Version</dt>
+                    <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+                      {draft.versionNumber ?? "-"}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-slate-400">Open Comments</dt>
+                    <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+                      {draft.openCommentCount}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-slate-400">Updated</dt>
+                    <dd className="mt-1 font-semibold text-slate-900 dark:text-white">
+                      {new Date(draft.updatedAt).toLocaleDateString("ko-KR")}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/studio/drafts/page.tsx
+++ b/app/studio/drafts/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { getDraftSummaries } from "@/services/draftRepository";
 
 const statusStyles: Record<string, string> = {
@@ -47,9 +48,10 @@ export default async function DraftStudioPage() {
       ) : (
         <div className="grid gap-4">
           {drafts.map((draft) => (
-            <article
+            <Link
               key={draft.id}
-              className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-800 dark:bg-slate-950"
+              href={`/studio/drafts/${draft.id}`}
+              className="block rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition-colors hover:border-slate-300 hover:shadow-md dark:border-slate-800 dark:bg-slate-950 dark:hover:border-slate-700"
             >
               <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                 <div className="space-y-3">
@@ -94,7 +96,7 @@ export default async function DraftStudioPage() {
                   </div>
                 </dl>
               </div>
-            </article>
+            </Link>
           ))}
         </div>
       )}

--- a/app/studio/drafts/page.tsx
+++ b/app/studio/drafts/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { StudioLogoutButton } from "@/components/studio/StudioLogoutButton";
 import { getDraftSummaries } from "@/services/draftRepository";
 
 const statusStyles: Record<string, string> = {
@@ -22,19 +23,22 @@ export default async function DraftStudioPage() {
 
   return (
     <section className="space-y-8">
-      <header className="space-y-3">
-        <span className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white">
-          Studio
-        </span>
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
-            Draft Queue
-          </h1>
-          <p className="max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
-            DB에 적재된 초안과 현재 리뷰 상태를 확인하는 화면입니다. 상세 리뷰와 인증은 다음 단계에서
-            이어집니다.
-          </p>
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-3">
+          <span className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white">
+            Studio
+          </span>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+              Draft Queue
+            </h1>
+            <p className="max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+              DB에 적재된 초안과 현재 리뷰 상태를 확인하는 화면입니다. 상세 리뷰와 인증은 다음 단계에서
+              이어집니다.
+            </p>
+          </div>
         </div>
+        <StudioLogoutButton />
       </header>
 
       {drafts.length === 0 ? (

--- a/app/studio/login/page.tsx
+++ b/app/studio/login/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { isAdminSessionAuthenticated } from "@/lib/auth/admin-session";
+import { StudioLoginForm } from "@/components/studio/StudioLoginForm";
+
+export default async function StudioLoginPage() {
+  const isAuthenticated = await isAdminSessionAuthenticated();
+
+  if (isAuthenticated) {
+    redirect("/studio/drafts");
+  }
+
+  return (
+    <section className="mx-auto max-w-md space-y-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+      <div className="space-y-3">
+        <span className="inline-flex items-center rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white">
+          Studio
+        </span>
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+          Admin Login
+        </h1>
+        <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
+          `.env`에 저장된 관리자 비밀번호로 스튜디오에 로그인합니다.
+        </p>
+      </div>
+
+      <StudioLoginForm />
+    </section>
+  );
+}

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+import { isAdminSessionAuthenticated } from "@/lib/auth/admin-session";
+
+export default async function StudioPage() {
+  const isAuthenticated = await isAdminSessionAuthenticated();
+
+  if (isAuthenticated) {
+    redirect("/studio/drafts");
+  }
+
+  redirect("/studio/login");
+}

--- a/architect.md
+++ b/architect.md
@@ -1,0 +1,1022 @@
+# Jeanne Log DB Migration Architecture
+
+## 목적
+
+`jeanne-log`를 정적 파일 기반 블로그에서 DB 기반 콘텐츠 플랫폼으로 전환한다.
+
+이번 전환의 목표는 단순한 저장소 변경이 아니다. 다음 워크플로를 자연스럽게 지원할 수 있어야 한다.
+
+- AI 파이프라인이 초안을 자동 생성
+- 초안이 비공개 리뷰 화면에 저장
+- 라인 단위 인라인 코멘트로 피드백 수집
+- 코멘트를 반영해 AI 재생성 반복
+- 최종 승인 후 발행
+- 발행 후 공개 블로그에 즉시 반영
+
+핵심 결론은 다음과 같다.
+
+- 콘텐츠의 source of truth는 파일이 아니라 DB 하나로 통합한다.
+- `jeanne-log`는 콘텐츠 시스템 오브 레코드가 된다.
+- `blog-pipeline-agent`는 생성 전용 워커 역할만 담당한다.
+- 초안 생성, 리뷰, 재생성, 발행 상태 전이는 모두 DB 기반으로 처리한다.
+
+## 현재 상태 요약
+
+### jeanne-log
+
+- `contents/article/*.mdx`를 직접 읽어 공개 글을 렌더링한다.
+- 초안, 버전, 코멘트, 잡 상태를 저장할 DB가 없다.
+- 관리자 화면, 인증, 내부 API가 없다.
+- 현재 구조는 "파일이 곧 발행 후보"라는 전제를 갖고 있다.
+
+### blog-pipeline-agent
+
+- LLM으로 생성한 초안을 `jeanne-log/contents/article`에 직접 파일로 쓴다.
+- 그 뒤 git branch 생성, commit, push, PR 생성까지 한 번에 수행한다.
+- 프로젝트 기반 글 생성 로직과 재작성 로직은 이미 자산으로 활용 가능하다.
+
+현재 구조의 문제는 초안 생성과 발행 후보 생성과 검토 채널이 모두 PR에 묶여 있다는 점이다. 앞으로 원하는 리뷰 워크플로는 PR이 아니라 애플리케이션 내부의 비공개 리뷰 공간에서 돌아가야 한다.
+
+## 목표 아키텍처
+
+### 시스템 역할 분리
+
+#### 1. jeanne-log
+
+역할:
+
+- 공개 블로그 렌더링
+- 관리자 인증
+- 비공개 초안 목록/리뷰 UI 제공
+- 코멘트 CRUD
+- 재생성 요청 생성
+- 발행 상태 전환
+- 내부 API 제공
+- DB schema와 migration 관리
+- 캐시 무효화 및 라우팅 관리
+
+즉, 콘텐츠 규칙과 상태 전이의 소유권은 `jeanne-log`가 가진다.
+
+#### 2. blog-pipeline-agent
+
+역할:
+
+- 세션 수집
+- 프로젝트/주간 초안 생성
+- LLM 호출
+- 재생성 job 소비
+- 결과물 제출
+- 실패/재시도 로그 관리
+
+즉, `blog-pipeline-agent`는 글을 "직접 발행"하지 않고 초안이나 새 버전을 생성해 제출하는 워커가 된다.
+
+#### 3. Postgres
+
+역할:
+
+- 초안, 공개 글, 버전, 코멘트, 잡 상태의 단일 저장소
+- 리뷰 워크플로와 발행 상태의 source of truth
+
+## 핵심 원칙
+
+### 1. DB를 단일 진실 원천으로 둔다
+
+- 공개 글도 DB에서 읽는다.
+- 초안도 DB에 저장한다.
+- 발행 상태도 DB에 저장한다.
+- 리뷰 코멘트도 DB에 저장한다.
+
+파일 시스템은 더 이상 운영 저장소가 아니다. 필요하면 마이그레이션용 입력 소스나 백업 용도로만 사용한다.
+
+### 2. DB 소유권은 jeanne-log가 가진다
+
+`blog-pipeline-agent`가 DB에 직접 접근하게 두지 않는다.
+
+이유:
+
+- schema coupling이 강해진다
+- 콘텐츠 규칙이 두 시스템으로 분산된다
+- 상태 전이 검증이 중복된다
+- 이후 schema 변경 비용이 커진다
+
+따라서 `blog-pipeline-agent`는 `jeanne-log`의 내부 API만 호출한다.
+
+### 3. 코멘트는 article이 아니라 version에 붙인다
+
+라인 단위 피드백은 특정 버전의 텍스트에 대해 유효하다. 재생성 후 줄이 이동하면 동일 코멘트를 자동 재사용하기 어렵다.
+
+따라서:
+
+- 코멘트는 `article_versions`에 연결
+- 재생성 시 새 버전 생성
+- 이전 코멘트는 이전 버전에 남김
+- 필요하면 UI에서 "이전 버전 코멘트"를 참조만 가능하게 제공
+
+### 4. 재생성은 동기 호출이 아니라 job 기반으로 처리한다
+
+관리자 화면에서 버튼을 눌렀을 때 바로 LLM 호출을 시작하지 않는다.
+
+흐름:
+
+- UI가 regeneration job 생성
+- 워커가 job을 polling
+- LLM 처리 후 새 버전 제출
+- UI가 상태를 polling 또는 revalidation으로 갱신
+
+이 구조가 UI 지연과 워커 실패를 분리한다.
+
+## 권장 기술 선택
+
+### jeanne-log
+
+- Next.js App Router 유지
+- Postgres 사용
+- Drizzle ORM 사용
+- Auth.js + GitHub OAuth 사용
+- 관리자 영역은 같은 앱 내 `/studio` 또는 `/drafts` 하위에 구성
+- 공개 렌더는 DB 기반 MDX source를 서버에서 렌더
+
+### blog-pipeline-agent
+
+- Python 유지
+- 기존 생성 로직 재사용
+- 내부 API client 추가
+- cron/launchd 기반 실행 유지 가능
+- 별도 메시지 브로커는 초기 단계에서 도입하지 않음
+
+### 왜 Postgres인가
+
+SQLite도 작은 단일 인스턴스 환경에서는 동작 가능하지만, 다음 이유로 Postgres가 더 적합하다.
+
+- 초안/버전/코멘트/잡 테이블이 늘어날 가능성이 높다
+- 향후 배포 환경이 고정 로컬 머신이 아닐 수 있다
+- row locking과 job polling 제어가 더 안정적이다
+- 운영 관점에서 확장과 백업이 쉽다
+
+## 데이터 모델
+
+최소 기준으로 아래 엔티티가 필요하다.
+
+### articles
+
+초안과 공개 글의 최상위 엔티티.
+
+권장 필드:
+
+- `id`
+- `slug`
+- `status` (`draft`, `in_review`, `regenerating`, `published`, `archived`)
+- `title`
+- `summary`
+- `current_version_id`
+- `published_version_id`
+- `created_by`
+- `created_at`
+- `updated_at`
+- `published_at`
+
+설명:
+
+- `current_version_id`: 리뷰 중인 최신 버전
+- `published_version_id`: 공개 중인 버전
+- 초안 상태에서도 slug를 미리 둘 수 있지만, 발행 시 최종 조정 가능하게 설계한다
+
+### article_versions
+
+본문 스냅샷과 생성 메타데이터를 보관한다.
+
+권장 필드:
+
+- `id`
+- `article_id`
+- `version_number`
+- `source_type` (`weekly`, `project`, `manual`, `regenerated`)
+- `mdx_source`
+- `plain_text_snapshot`
+- `line_index_json`
+- `generation_prompt_snapshot`
+- `generation_context_json`
+- `model_name`
+- `created_at`
+
+설명:
+
+- `mdx_source`: 실제 렌더와 발행에 쓰이는 canonical source
+- `plain_text_snapshot`: 라인 선택과 비교 UI용 파생 데이터
+- `line_index_json`: 줄 번호와 source range 매핑
+
+### review_comments
+
+인라인 코멘트 저장소.
+
+권장 필드:
+
+- `id`
+- `article_version_id`
+- `start_line`
+- `end_line`
+- `selected_text`
+- `body`
+- `status` (`open`, `resolved`, `dismissed`)
+- `created_by`
+- `created_at`
+- `updated_at`
+
+설명:
+
+- 선택 범위를 line number 기준으로 저장
+- `selected_text`는 라인 drift가 발생했을 때 사람이 맥락을 이해하는 데 유용
+
+### regeneration_jobs
+
+비동기 생성 요청 큐.
+
+권장 필드:
+
+- `id`
+- `article_id`
+- `base_version_id`
+- `status` (`queued`, `running`, `failed`, `completed`)
+- `job_type` (`initial_draft`, `regenerate`)
+- `input_payload_json`
+- `result_version_id`
+- `error_message`
+- `attempt_count`
+- `locked_at`
+- `worker_id`
+- `created_at`
+- `updated_at`
+
+설명:
+
+- 초기 초안 생성도 동일한 job abstraction으로 맞출 수 있다
+- 직접 DB queue만으로도 초기 단계는 충분하다
+
+### publication_events
+
+발행/보관 이력.
+
+권장 필드:
+
+- `id`
+- `article_id`
+- `from_version_id`
+- `to_version_id`
+- `event_type` (`published`, `unpublished`, `archived`)
+- `actor`
+- `created_at`
+
+### admin_users
+
+관리자 인증 주체.
+
+GitHub OAuth를 쓸 경우 최소 매핑만 두면 된다.
+
+권장 필드:
+
+- `id`
+- `github_user_id`
+- `email`
+- `role`
+- `created_at`
+
+## 콘텐츠 표현 전략
+
+본문 포맷은 DB로 옮기더라도 MDX source를 유지한다.
+
+이유:
+
+- 기존 콘텐츠가 이미 MDX 기반이다
+- 현재 렌더링 구조를 크게 바꾸지 않아도 된다
+- 발행 결과와 초안 결과를 같은 포맷으로 유지할 수 있다
+
+정리하면:
+
+- canonical content: `mdx_source`
+- review-friendly derivative: `plain_text_snapshot`, `line_index_json`
+
+리뷰 화면은 source-oriented editor/viewer로 구현하는 것이 맞다. WYSIWYG보다 라인 단위 범위 선택과 diff 비교에 유리하다.
+
+## 인증과 권한
+
+### 관리자 인증
+
+권장 방식:
+
+- Auth.js
+- GitHub OAuth
+- 허용된 GitHub 계정만 접근 허용
+
+이유:
+
+- 1인 운영 환경에 적합
+- 비밀번호 직접 관리보다 안전
+- 추후 관리자 추가도 단순
+
+### 머신 인증
+
+`blog-pipeline-agent`는 내부 API 호출 시 별도 service token을 사용한다.
+
+권장 방식:
+
+- `Authorization: Bearer <INTERNAL_API_TOKEN>`
+- `jeanne-log` 서버에서 토큰 검증
+
+이렇게 권한을 분리한다.
+
+- 사람: GitHub OAuth 세션
+- 파이프라인: internal service token
+
+## API 경계 설계
+
+DB는 `jeanne-log`가 소유하고, `blog-pipeline-agent`는 내부 API로만 접근한다.
+
+### 내부 API
+
+파이프라인 전용.
+
+권장 엔드포인트:
+
+- `POST /api/internal/drafts`
+- `GET /api/internal/jobs/next?type=regenerate`
+- `POST /api/internal/jobs/:id/complete`
+- `POST /api/internal/jobs/:id/fail`
+
+필요시 추가:
+
+- `POST /api/internal/articles/:id/versions`
+- `POST /api/internal/articles/:id/regenerations`
+
+### 관리자 API
+
+스튜디오 UI 전용.
+
+권장 엔드포인트:
+
+- `GET /api/admin/drafts`
+- `GET /api/admin/drafts/:id`
+- `POST /api/admin/comments`
+- `PATCH /api/admin/comments/:id`
+- `DELETE /api/admin/comments/:id`
+- `POST /api/admin/drafts/:id/regenerate`
+- `POST /api/admin/drafts/:id/publish`
+- `POST /api/admin/drafts/:id/archive`
+
+## 관리자 UI 구조
+
+권장 라우트:
+
+- `/studio`
+- `/studio/drafts`
+- `/studio/drafts/[id]`
+
+### 1. 초안 목록 화면
+
+표시 항목:
+
+- 제목
+- 상태
+- 생성 시각
+- 마지막 버전 번호
+- 열린 코멘트 수
+- 마지막 재생성 시각
+
+### 2. 리뷰 화면
+
+구성:
+
+- 상단: 제목, 상태, 버전 선택, 재생성 버튼, 발행 버튼
+- 메인 패널: 라인 번호가 있는 source view
+- 보조 패널: 코멘트 목록
+- 비교 모드: 이전 버전과 현재 버전 diff
+
+### 3. 리뷰 인터랙션
+
+동작:
+
+- 라인 드래그로 범위 선택
+- 선택 범위 끝에 코멘트 버튼 노출
+- 선택 범위 아래 인라인 입력창 표시
+- 저장 시 하이라이트와 코멘트 앵커 표시
+- 하이라이트 클릭 시 코멘트 확인
+- 코멘트 수정/삭제 가능
+
+### 4. 재생성 흐름
+
+- 열린 코멘트를 포함해 재생성 요청 생성
+- job 상태가 `running`으로 바뀌면 로딩 표시
+- 완료 시 새 버전 생성
+- 탭 또는 split view로 버전 비교
+
+## 공개 블로그 렌더링 구조
+
+정적 파일 기반 구조를 제거하고 공개 글도 DB에서 읽는다.
+
+### 읽기 경로
+
+- 목록 페이지: `status = published`
+- 상세 페이지: `slug` + `published_version_id` 기준 조회
+
+### 캐시 전략
+
+발행 시:
+
+- posts 목록 캐시 무효화
+- 해당 slug 상세 캐시 무효화
+
+Next.js의 `revalidateTag` 또는 `revalidatePath`를 활용할 수 있다.
+
+### 발행 의미
+
+발행은 더 이상 파일 생성이나 git push가 아니다.
+
+발행은 다음 상태 전이로 정의한다.
+
+- `published_version_id` 설정
+- `status = published`
+- `published_at` 기록
+- 캐시 무효화
+
+## blog-pipeline-agent 재구성
+
+현재 스크립트의 마지막 출력 경로를 바꾸는 것이 핵심이다.
+
+### 기존
+
+- 초안 생성
+- MDX 파일 생성
+- git branch 생성
+- commit / push
+- PR 생성
+
+### 변경 후
+
+- 초안 생성
+- 내부 API로 draft 생성 또는 version 제출
+- 필요하면 regeneration job 소비
+
+### 스크립트별 방향
+
+#### weekly_publish.py
+
+현재:
+
+- `refined/*_sonnet.md`를 읽고 파일 생성 후 PR 생성
+
+변경:
+
+- `refined/*_sonnet.md`를 읽고 draft/article_version 생성 API 호출
+- `published.json`은 "이미 초안으로 적재됨" 기준으로 관리 가능
+- git/PR 로직 제거
+
+#### publish_project.py
+
+현재:
+
+- 프로젝트 소스에서 장문 블로그 글 생성
+- article 파일 생성 또는 PR 생성
+
+변경:
+
+- 생성 결과를 draft version으로 제출
+- source metadata를 함께 전송
+
+#### nightly_refine.py
+
+현재:
+
+- 세션을 누적해 thread/final 산출물 생성
+
+변경:
+
+- 일단 유지 가능
+- 다만 최종 산출물의 downstream 소비자는 파일 생성 스크립트가 아니라 draft submitter가 된다
+
+## 리뷰/재생성 시퀀스
+
+### 초기 초안 생성
+
+1. `blog-pipeline-agent`가 초안 생성
+2. `POST /api/internal/drafts` 호출
+3. `jeanne-log`가 `articles` + `article_versions(v1)` 저장
+4. 관리자 목록에 초안 표시
+
+### 리뷰
+
+1. 사용자가 초안 상세로 진입
+2. 특정 버전의 텍스트를 라인 단위로 확인
+3. 코멘트 CRUD 수행
+
+### 재생성
+
+1. 사용자가 재생성 버튼 클릭
+2. `regeneration_jobs`에 `queued` row 생성
+3. `blog-pipeline-agent`가 job polling
+4. 워커가 base version + open comments + metadata로 프롬프트 구성
+5. LLM 호출 후 새 버전 생성
+6. `jobs/:id/complete` 호출
+7. `article_versions(v2)` 생성, `current_version_id` 갱신
+
+### 발행
+
+1. 사용자가 특정 버전을 확인
+2. 발행 버튼 클릭
+3. `published_version_id` 갱신
+4. `status = published`
+5. 캐시 무효화
+6. 초안은 archived 또는 published 상태로 정리
+
+## 마이그레이션 전략
+
+한 번에 전환하지 말고 단계적으로 옮긴다.
+
+### Phase 1. DB 도입과 legacy import
+
+목표:
+
+- Postgres 도입
+- Drizzle schema 작성
+- 기존 `contents/article/*.mdx`를 DB로 import
+- 파일 기반 읽기는 일단 유지 가능
+
+산출물:
+
+- schema
+- migration
+- import script
+
+### Phase 2. 관리자 스튜디오 구축
+
+목표:
+
+- 관리자 인증
+- draft list/detail UI
+- comment CRUD
+- regenerate job 생성
+
+산출물:
+
+- `/studio` 라우트
+- admin API
+- review UI
+
+### Phase 3. 파이프라인 쓰기 경로 전환
+
+목표:
+
+- `blog-pipeline-agent`가 파일/PR 대신 내부 API로 초안 제출
+- regeneration worker 동작
+
+산출물:
+
+- internal API client
+- draft submitter
+- job worker
+
+### Phase 4. 공개 읽기 경로 전환
+
+목표:
+
+- 공개 블로그도 DB에서 읽기
+- 발행 상태 반영
+- 파일 기반 의존 제거
+
+산출물:
+
+- DB reader service
+- published list/detail 쿼리
+- cache invalidation
+
+### Phase 5. 파일 기반 운영 제거
+
+목표:
+
+- `contents/article`를 운영 source에서 제외
+- 파일 기반 publish 로직 완전 삭제
+
+## 현실적인 1차 구현 범위
+
+처음 스프린트는 아래까지를 권장한다.
+
+1. Postgres + Drizzle 도입
+2. article/version/comment/job schema 작성
+3. legacy MDX import script 작성
+4. GitHub OAuth 관리자 인증 추가
+5. `/studio/drafts` 목록 화면 추가
+6. `/studio/drafts/[id]` 상세/코멘트 CRUD 구현
+7. regeneration job 생성 API 구현
+8. `blog-pipeline-agent`의 draft submit 연동 추가
+
+이 단계에서는 아직 공개 읽기 전체 전환과 발행 UI까지 욕심내지 않는 것이 좋다. 먼저 초안 생성과 리뷰 루프를 안정화해야 한다.
+
+## 오픈 이슈
+
+아래는 구현 전에 최종 결정이 필요한 항목이다.
+
+### 1. slug 정책
+
+- 초안 생성 시 slug를 고정할지
+- 발행 직전 수정 가능하게 할지
+
+권장:
+
+- 초안 시 provisional slug 허용
+- 발행 직전 최종 확정
+
+### 2. 코멘트 승계 정책
+
+재생성 후 기존 코멘트를 새 버전에 자동 승계할지 여부.
+
+권장:
+
+- 자동 승계하지 않음
+- 이전 버전 코멘트는 기록으로 유지
+- 필요하면 새 버전에 수동으로 다시 달게 함
+
+### 3. 공개 글의 SEO 메타
+
+DB 기반 전환 후에도 `generateMetadata`에서 title/description/OpenGraph를 안정적으로 구성해야 한다.
+
+### 4. import 이후 파일 보존 정책
+
+권장:
+
+- 초기에는 백업으로 유지
+- 운영 읽기 경로에서 제외
+- 최종 안정화 후 archive-only 취급
+
+## 최종 결론
+
+이 프로젝트는 "정적 블로그에 초안 페이지를 붙이는 일"이 아니라, `jeanne-log`를 중심으로 한 콘텐츠 플랫폼 재구성 작업이다.
+
+가장 중요한 아키텍처 결정은 아래 세 가지다.
+
+1. 콘텐츠 저장소는 DB로 통합한다.
+2. `jeanne-log`가 콘텐츠와 상태 전이의 소유권을 가진다.
+3. `blog-pipeline-agent`는 내부 API를 통해 초안과 재생성 결과를 제출하는 워커가 된다.
+
+이 방향으로 가면 이후 기능 확장이 자연스럽다.
+
+- 버전 비교
+- 발행 예약
+- 코멘트 해결 상태 추적
+- 여러 생성 전략 실험
+- 품질 메트릭 축적
+
+반대로 파일 기반을 유지한 채 부분 기능만 붙이면 PR, 파일 쓰기, 리뷰 UI, 발행 상태가 서로 엮여서 계속 구조적 마찰이 생긴다.
+
+## 기능별 체크리스트
+
+아래 체크리스트는 기능 단위로 프론트, DB, API를 나눠서 정리한다. 구현 시에는 세 축을 병렬로 보지 말고, 기능 단위로 묶어서 완료하는 방식으로 진행하는 것이 좋다.
+
+### 1. 인증 및 관리자 접근 제어
+
+#### Frontend
+
+- [ ] 관리자 로그인 진입 화면 구성
+- [ ] 로그인 성공 후 `/studio` 또는 `/studio/drafts`로 이동 처리
+- [ ] 비로그인 상태에서 관리자 경로 접근 시 로그인 페이지 또는 403 화면 연결
+- [ ] 관리자 레이아웃과 공개 블로그 레이아웃 분리
+- [ ] 관리자 전용 네비게이션 구성
+
+#### DB
+
+- [ ] `admin_users` 테이블 생성
+- [ ] GitHub OAuth 사용자 식별 필드 정의 (`github_user_id`, `email`, `role`)
+- [ ] 허용 사용자 시드 데이터 입력 방식 정의
+
+#### API
+
+- [ ] Auth.js 세션 검증 로직 구성
+- [ ] 관리자 전용 API 보호 미들웨어 구현
+- [ ] 내부 API와 관리자 API의 인증 방식을 분리
+- [ ] 관리자 권한 검증 유틸 작성
+
+### 2. 레거시 글 DB 마이그레이션
+
+#### Frontend
+
+- [ ] 운영 UI 영향 없이 DB import 이후 공개 목록/상세 fallback 전략 정의
+- [ ] 관리자 화면에서 import된 글을 조회할 필요가 있는지 결정
+
+#### DB
+
+- [ ] `articles` 테이블 생성
+- [ ] `article_versions` 테이블 생성
+- [ ] 기존 MDX에서 `slug`, `title`, `summary`, `date`, `tags`, `author` 추출 규칙 정의
+- [ ] import 시 `published_version_id`와 `current_version_id` 초기값 설정
+- [ ] import 대상 파일과 DB row의 매핑 로그 저장 방식 정의
+
+#### API
+
+- [ ] legacy import script 작성
+- [ ] 중복 import 방지 로직 추가
+- [ ] import dry-run 모드 지원
+- [ ] import 후 검증용 조회 API 또는 검증 스크립트 작성
+
+### 3. 초안 생성 유입
+
+#### Frontend
+
+- [ ] 초안 목록에서 AI 생성 초안이 바로 보이도록 상태 뱃지 구성
+- [ ] 초안 생성 직후 상세 화면으로 이동 가능한 UX 여부 결정
+
+#### DB
+
+- [ ] `articles.status = draft` 기본 흐름 정의
+- [ ] 초안 생성 시 `article_versions(v1)` 생성 규칙 정의
+- [ ] `source_type`과 생성 출처 메타데이터 저장 컬럼 정의
+- [ ] `plain_text_snapshot`, `line_index_json` 생성 규칙 정의
+
+#### API
+
+- [ ] `POST /api/internal/drafts` 구현
+- [ ] 파이프라인 토큰 인증 구현
+- [ ] payload schema 검증 추가
+- [ ] idempotency 키 또는 중복 생성 방지 규칙 정의
+- [ ] draft 생성 후 반환 데이터 포맷 정의
+
+### 4. 초안 목록 화면
+
+#### Frontend
+
+- [ ] `/studio/drafts` 라우트 생성
+- [ ] 목록 테이블 또는 카드 UI 구성
+- [ ] 상태, 생성일, 마지막 수정일, 버전 수, 열린 코멘트 수 표시
+- [ ] draft / regenerating / published / archived 필터 제공
+- [ ] 정렬 기준 정의 (최근 수정 우선 권장)
+- [ ] 빈 상태 UI 구성
+- [ ] 로딩/에러 상태 UI 구성
+
+#### DB
+
+- [ ] 목록 조회에 필요한 집계 쿼리 설계
+- [ ] 열린 코멘트 수 계산 방식 정의
+- [ ] 최신 버전 조인 전략 정의
+- [ ] status + updated_at 인덱스 추가
+
+#### API
+
+- [ ] `GET /api/admin/drafts` 구현
+- [ ] status/filter/query params 설계
+- [ ] pagination 또는 cursor 방식 결정
+- [ ] 목록 응답 DTO 정의
+
+### 5. 초안 상세 및 리뷰 화면
+
+#### Frontend
+
+- [ ] `/studio/drafts/[id]` 라우트 생성
+- [ ] 버전 선택 UI 구성
+- [ ] 라인 번호가 포함된 본문 뷰어 구현
+- [ ] 긴 문서 스크롤 성능 검토
+- [ ] 코멘트 패널 위치 결정 (우측 또는 하단)
+- [ ] 상태 헤더 구성 (draft/in_review/regenerating/published)
+- [ ] 새로고침 후 선택 버전/스크롤 위치 유지 여부 결정
+
+#### DB
+
+- [ ] 버전별 본문 스냅샷 조회 쿼리 설계
+- [ ] line index 저장 포맷 검증
+- [ ] 특정 버전에 달린 코멘트 조회 쿼리 설계
+
+#### API
+
+- [ ] `GET /api/admin/drafts/:id` 구현
+- [ ] article + current version + version list + comment summary 응답 구조 정의
+- [ ] 특정 version 지정 조회 지원 여부 결정
+
+### 6. 인라인 코멘트 작성/수정/삭제
+
+#### Frontend
+
+- [ ] 드래그로 라인 범위 선택 구현
+- [ ] 선택 범위 끝에 코멘트 버튼 표시
+- [ ] 선택 범위 아래 인라인 입력창 표시
+- [ ] 코멘트 저장 후 하이라이트 렌더링
+- [ ] 하이라이트 클릭 시 코멘트 상세 노출
+- [ ] 코멘트 수정 UI 구현
+- [ ] 코멘트 삭제 UI 구현
+- [ ] 코멘트 없는 상태와 다수 코멘트 상태 UX 정리
+
+#### DB
+
+- [ ] `review_comments` 테이블 생성
+- [ ] `article_version_id + start_line + end_line` 조회 인덱스 추가
+- [ ] comment status (`open`, `resolved`, `dismissed`) 컬럼 정의
+- [ ] selected text snapshot 저장 규칙 정의
+
+#### API
+
+- [ ] `POST /api/admin/comments` 구현
+- [ ] `PATCH /api/admin/comments/:id` 구현
+- [ ] `DELETE /api/admin/comments/:id` 구현
+- [ ] 코멘트 payload validation 추가
+- [ ] 코멘트 작성 시 version 범위 검증 추가
+
+### 7. 코멘트 목록 패널
+
+#### Frontend
+
+- [ ] 현재 버전의 코멘트 리스트 표시
+- [ ] 클릭 시 본문 해당 라인으로 스크롤 이동
+- [ ] open / resolved 필터 지원
+- [ ] 생성순 / 라인순 정렬 지원
+- [ ] 코멘트 개수 요약 UI 제공
+
+#### DB
+
+- [ ] 코멘트 정렬 기준 인덱스 검토
+- [ ] 버전별 코멘트 집계 쿼리 설계
+
+#### API
+
+- [ ] 상세 API에 코멘트 리스트를 포함할지 별도 API로 분리할지 결정
+- [ ] 필요 시 `GET /api/admin/drafts/:id/comments` 추가
+
+### 8. 버전 비교
+
+#### Frontend
+
+- [ ] 버전 선택 드롭다운 또는 탭 UI 구현
+- [ ] 두 버전 비교 모드 진입 UX 구성
+- [ ] split view 또는 unified diff 방식 결정
+- [ ] added / removed / changed 라인 시각 표현 정의
+- [ ] 이전 버전 코멘트 참고 보기 지원 여부 결정
+
+#### DB
+
+- [ ] 버전 메타데이터 조회 최적화
+- [ ] diff 계산을 DB에 저장할지 요청 시 계산할지 결정
+
+#### API
+
+- [ ] `GET /api/admin/drafts/:id/versions` 구현 여부 결정
+- [ ] 필요 시 `GET /api/admin/drafts/:id/diff?base=x&target=y` 구현
+- [ ] diff 응답 포맷 정의
+
+### 9. 재생성 요청
+
+#### Frontend
+
+- [ ] 재생성 버튼 배치
+- [ ] 열린 코멘트가 없을 때 버튼 정책 정의
+- [ ] 재생성 확인 모달 또는 요약 패널 제공
+- [ ] 재생성 시작 후 버튼 비활성화
+- [ ] 진행 중 로딩 상태 표시
+
+#### DB
+
+- [ ] `regeneration_jobs` 테이블 생성
+- [ ] job 상태 전이 정의 (`queued`, `running`, `failed`, `completed`)
+- [ ] `base_version_id` 저장 규칙 정의
+- [ ] 재시도 횟수와 실패 사유 저장 컬럼 정의
+- [ ] job polling용 인덱스 추가
+
+#### API
+
+- [ ] `POST /api/admin/drafts/:id/regenerate` 구현
+- [ ] 열린 코멘트 스냅샷을 job payload에 포함할지 결정
+- [ ] 동일 draft에 대해 중복 queued job 방지
+- [ ] regenerate 요청 응답 포맷 정의
+
+### 10. 재생성 워커 처리
+
+#### Frontend
+
+- [ ] job 상태 polling 또는 서버 재검증 전략 결정
+- [ ] 실패 시 사용자에게 에러 메시지 표시
+- [ ] 완료 시 새 버전 자동 선택 여부 결정
+
+#### DB
+
+- [ ] job lock 처리 방식 정의
+- [ ] `worker_id`, `locked_at` 사용 규칙 정의
+- [ ] job 완료 시 `article_versions`와 `articles.current_version_id` 갱신 트랜잭션 설계
+
+#### API
+
+- [ ] `GET /api/internal/jobs/next?type=regenerate` 구현
+- [ ] `POST /api/internal/jobs/:id/complete` 구현
+- [ ] `POST /api/internal/jobs/:id/fail` 구현
+- [ ] worker 중복 수신 방지 로직 추가
+- [ ] job completion payload validation 추가
+
+### 11. 발행
+
+#### Frontend
+
+- [ ] 발행 버튼 배치
+- [ ] 발행 대상 버전 명시
+- [ ] slug/title/summary 최종 수정 UI 필요 여부 결정
+- [ ] 발행 확인 모달 구성
+- [ ] 발행 완료 후 공개 링크 제공
+
+#### DB
+
+- [ ] `published_version_id` 갱신 규칙 정의
+- [ ] `published_at` 기록
+- [ ] `publication_events` 테이블 생성
+- [ ] 기존 published 글 재발행 시 이벤트 기록 정책 정의
+
+#### API
+
+- [ ] `POST /api/admin/drafts/:id/publish` 구현
+- [ ] slug uniqueness 검증
+- [ ] publish 트랜잭션 처리
+- [ ] 발행 후 캐시 무효화 호출
+
+### 12. 아카이브
+
+#### Frontend
+
+- [ ] 아카이브 버튼 또는 메뉴 제공
+- [ ] archived 초안 목록 필터 제공
+- [ ] archived 초안 읽기 전용 정책 여부 결정
+
+#### DB
+
+- [ ] `status = archived` 정책 정의
+- [ ] archived_at 컬럼 필요 여부 결정
+
+#### API
+
+- [ ] `POST /api/admin/drafts/:id/archive` 구현
+- [ ] published 글의 archive 허용 정책 정의
+
+### 13. 공개 글 조회 전환
+
+#### Frontend
+
+- [ ] 홈 목록을 DB 기반으로 전환
+- [ ] 상세 페이지를 DB 기반으로 전환
+- [ ] 기존 파일 기반 렌더와 시각 차이 없는지 점검
+- [ ] 공개 페이지 SEO 메타 동작 검증
+
+#### DB
+
+- [ ] published 글 조회 인덱스 추가
+- [ ] slug unique index 추가
+- [ ] 목록 조회용 정렬 인덱스 검토
+
+#### API
+
+- [ ] 서버 서비스 계층에서 published article 조회 함수 구현
+- [ ] slug 기반 detail 조회 함수 구현
+- [ ] 캐시/revalidate 전략 구현
+
+### 14. 파이프라인 연동 전환
+
+#### Frontend
+
+- [ ] 관리자 화면에서 파이프라인 생성 초안과 수동 초안을 구분 표시할지 결정
+
+#### DB
+
+- [ ] source metadata 저장 컬럼 확정
+- [ ] 외부 파이프라인 식별자 저장 방식 정의
+
+#### API
+
+- [ ] `blog-pipeline-agent`에서 사용할 draft submit payload 확정
+- [ ] 기존 `weekly_publish.py`의 PR 생성 제거
+- [ ] 기존 `publish_project.py`의 파일 출력 제거
+- [ ] 내부 API 호출 실패 시 재시도 정책 정의
+
+### 15. 운영 및 관측성
+
+#### Frontend
+
+- [ ] 관리자 화면에 최근 실패 job 노출 여부 결정
+- [ ] 사용자 액션 토스트/에러 피드백 일관화
+
+#### DB
+
+- [ ] audit log 테이블 필요 여부 결정
+- [ ] 오래된 job/archive 정리 정책 정의
+- [ ] 백업 정책 정의
+
+#### API
+
+- [ ] 내부 API 요청 로그 추가
+- [ ] job 실패 사유 구조화
+- [ ] 관리자 액션 로그 기록
+- [ ] health check 또는 최소 운영 점검 포인트 정의
+
+## 권장 구현 순서 체크리스트
+
+아래 순서로 진행하는 것이 가장 안전하다.
+
+- [ ] Postgres + Drizzle 도입
+- [ ] `articles`, `article_versions`, `review_comments`, `regeneration_jobs` schema 작성
+- [ ] legacy import script 작성 및 검증
+- [ ] 관리자 인증 도입
+- [ ] 초안 목록 화면 구현
+- [ ] 초안 상세/리뷰 화면 구현
+- [ ] 인라인 코멘트 CRUD 구현
+- [ ] regeneration job 생성 API 구현
+- [ ] `blog-pipeline-agent` 초안 제출 연동
+- [ ] regeneration worker 연동
+- [ ] 발행 기능 구현
+- [ ] 공개 글 DB 조회 전환
+- [ ] 파일 기반 publish 경로 제거

--- a/components/studio/CommentManager.tsx
+++ b/components/studio/CommentManager.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { DraftComment } from "@/types";
+
+type CommentManagerProps = {
+  articleVersionId: string | null;
+  lineCount: number;
+  initialComments: DraftComment[];
+};
+
+export function CommentManager({
+  articleVersionId,
+  lineCount,
+  initialComments,
+}: CommentManagerProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [startLine, setStartLine] = useState(1);
+  const [endLine, setEndLine] = useState(1);
+  const [selectedText, setSelectedText] = useState("");
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function refreshAfterMutation(successMessage: string) {
+    setMessage(successMessage);
+    setError(null);
+    startTransition(() => {
+      router.refresh();
+    });
+  }
+
+  async function handleCreateComment() {
+    if (!articleVersionId) {
+      setError("Current version is not available.");
+      return;
+    }
+
+    setMessage(null);
+    setError(null);
+
+    const response = await fetch("/api/admin/comments", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        articleVersionId,
+        startLine,
+        endLine,
+        selectedText,
+        body,
+      }),
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setError(payload.error ?? "Failed to create comment.");
+      return;
+    }
+
+    setSelectedText("");
+    setBody("");
+    await refreshAfterMutation("Comment created.");
+  }
+
+  async function handleResolveComment(commentId: string, nextStatus: DraftComment["status"]) {
+    setMessage(null);
+    setError(null);
+
+    const response = await fetch(`/api/admin/comments/${commentId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        status: nextStatus,
+      }),
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setError(payload.error ?? "Failed to update comment.");
+      return;
+    }
+
+    await refreshAfterMutation(`Comment marked as ${nextStatus}.`);
+  }
+
+  async function handleDeleteComment(commentId: string) {
+    setMessage(null);
+    setError(null);
+
+    const response = await fetch(`/api/admin/comments/${commentId}`, {
+      method: "DELETE",
+    });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setError(payload.error ?? "Failed to delete comment.");
+      return;
+    }
+
+    await refreshAfterMutation("Comment deleted.");
+  }
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+      <header className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+          Comments
+        </h2>
+        <span className="text-xs text-slate-400">{initialComments.length} items</span>
+      </header>
+
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
+        <div className="grid gap-4">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="grid gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                Start Line
+              </span>
+              <input
+                type="number"
+                min={1}
+                max={Math.max(lineCount, 1)}
+                value={startLine}
+                onChange={(event) => setStartLine(Number(event.target.value))}
+                className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+              />
+            </label>
+            <label className="grid gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                End Line
+              </span>
+              <input
+                type="number"
+                min={1}
+                max={Math.max(lineCount, 1)}
+                value={endLine}
+                onChange={(event) => setEndLine(Number(event.target.value))}
+                className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+              />
+            </label>
+          </div>
+
+          <label className="grid gap-2">
+            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+              Selected Text Snapshot
+            </span>
+            <textarea
+              rows={4}
+              value={selectedText}
+              onChange={(event) => setSelectedText(event.target.value)}
+              className="rounded-2xl border border-slate-200 bg-white px-4 py-3 font-mono text-sm leading-6 text-slate-900 outline-none dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <label className="grid gap-2">
+            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+              Comment
+            </span>
+            <textarea
+              rows={4}
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-900 outline-none dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void handleCreateComment()}
+            disabled={isPending || !articleVersionId}
+            className="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-slate-950"
+          >
+            {isPending ? "Saving..." : "Add Comment"}
+          </button>
+        </div>
+      </div>
+
+      {message ? <p className="mt-4 text-sm font-medium text-emerald-600 dark:text-emerald-400">{message}</p> : null}
+      {error ? <p className="mt-4 text-sm font-medium text-rose-600 dark:text-rose-400">{error}</p> : null}
+
+      {initialComments.length === 0 ? (
+        <p className="mt-5 text-sm leading-6 text-slate-500 dark:text-slate-400">
+          아직 코멘트가 없습니다. 라인 범위를 지정해서 수동으로 코멘트를 추가할 수 있습니다.
+        </p>
+      ) : (
+        <div className="mt-5 space-y-3">
+          {initialComments.map((comment) => (
+            <article
+              key={comment.id}
+              className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+                  L{comment.startLine}
+                  {comment.startLine !== comment.endLine ? `-L${comment.endLine}` : ""}
+                </span>
+                <span className="rounded-full bg-slate-200 px-2 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                  {comment.status}
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">{comment.body}</p>
+              <pre className="mt-3 overflow-x-auto rounded-xl bg-white px-3 py-2 font-mono text-xs leading-5 text-slate-500 dark:bg-slate-950 dark:text-slate-400">
+                {comment.selectedText}
+              </pre>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {comment.status !== "resolved" ? (
+                  <button
+                    type="button"
+                    onClick={() => void handleResolveComment(comment.id, "resolved")}
+                    className="rounded-full border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:border-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-white"
+                  >
+                    Mark Resolved
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => void handleResolveComment(comment.id, "open")}
+                    className="rounded-full border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:border-slate-900 dark:border-slate-700 dark:text-slate-200 dark:hover:border-white"
+                  >
+                    Reopen
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => void handleDeleteComment(comment.id)}
+                  className="rounded-full border border-rose-200 px-3 py-1.5 text-xs font-semibold text-rose-700 transition hover:border-rose-500 dark:border-rose-900/60 dark:text-rose-300"
+                >
+                  Delete
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/studio/DraftEditor.tsx
+++ b/components/studio/DraftEditor.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+type DraftEditorProps = {
+  draftId: string;
+  initialTitle: string;
+  initialSummary: string;
+  initialContent: string;
+};
+
+export function DraftEditor({
+  draftId,
+  initialTitle,
+  initialSummary,
+  initialContent,
+}: DraftEditorProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [title, setTitle] = useState(initialTitle);
+  const [summary, setSummary] = useState(initialSummary);
+  const [content, setContent] = useState(initialContent);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isDirty =
+    title !== initialTitle || summary !== initialSummary || content !== initialContent;
+
+  async function handleSave() {
+    setMessage(null);
+    setError(null);
+
+    const response = await fetch(`/api/admin/drafts/${draftId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title,
+        summary,
+        mdxSource: content,
+      }),
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setError(payload.error ?? "Failed to save draft.");
+      return;
+    }
+
+    setMessage(`Saved as version ${payload.versionNumber}.`);
+    startTransition(() => {
+      router.refresh();
+    });
+  }
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+      <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Editor
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+            AI 결과와 별개로 제목, 요약, 본문을 직접 수정해 새 manual 버전을 만들 수 있습니다.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={isPending || !isDirty}
+          className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-slate-950"
+        >
+          {isPending ? "Saving..." : "Save Draft"}
+        </button>
+      </header>
+
+      <div className="grid gap-4">
+        <label className="grid gap-2">
+          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+            Title
+          </span>
+          <input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none ring-0 transition focus:border-slate-400 dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+          />
+        </label>
+
+        <label className="grid gap-2">
+          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+            Summary
+          </span>
+          <textarea
+            value={summary}
+            onChange={(event) => setSummary(event.target.value)}
+            rows={3}
+            className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-900 outline-none ring-0 transition focus:border-slate-400 dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+          />
+        </label>
+
+        <label className="grid gap-2">
+          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+            MDX Source
+          </span>
+          <textarea
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+            rows={18}
+            className="min-h-[420px] rounded-2xl border border-slate-200 bg-white px-4 py-3 font-mono text-sm leading-6 text-slate-900 outline-none ring-0 transition focus:border-slate-400 dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+          />
+        </label>
+      </div>
+
+      {message ? (
+        <p className="mt-4 text-sm font-medium text-emerald-600 dark:text-emerald-400">{message}</p>
+      ) : null}
+      {error ? (
+        <p className="mt-4 text-sm font-medium text-rose-600 dark:text-rose-400">{error}</p>
+      ) : null}
+    </section>
+  );
+}

--- a/components/studio/RegenerateDraftButton.tsx
+++ b/components/studio/RegenerateDraftButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+type RegenerateDraftButtonProps = {
+  draftId: string;
+  disabled?: boolean;
+  openCommentCount: number;
+};
+
+export function RegenerateDraftButton({
+  draftId,
+  disabled = false,
+  openCommentCount,
+}: RegenerateDraftButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRegenerate() {
+    setMessage(null);
+    setError(null);
+
+    const response = await fetch(`/api/admin/drafts/${draftId}/regenerate`, {
+      method: "POST",
+    });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setError(payload.error ?? "Failed to queue regeneration.");
+      return;
+    }
+
+    setMessage("Regeneration queued.");
+    startTransition(() => {
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <button
+        type="button"
+        onClick={() => void handleRegenerate()}
+        disabled={disabled || isPending}
+        className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-900 transition hover:border-slate-900 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:hover:border-white"
+      >
+        {isPending ? "Queueing..." : "Regenerate"}
+      </button>
+      <p className="text-xs text-slate-400">
+        Open comments: {openCommentCount}
+      </p>
+      {message ? <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400">{message}</p> : null}
+      {error ? <p className="text-xs font-medium text-rose-600 dark:text-rose-400">{error}</p> : null}
+    </div>
+  );
+}

--- a/components/studio/StudioLoginForm.tsx
+++ b/components/studio/StudioLoginForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { FormEvent, useState, useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export function StudioLoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const nextPath = searchParams.get("next") || "/studio/drafts";
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    const response = await fetch("/api/auth/admin/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ password }),
+    });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      setError(payload.error ?? "Login failed.");
+      return;
+    }
+
+    startTransition(() => {
+      router.replace(nextPath);
+      router.refresh();
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-4">
+      <label className="grid gap-2">
+        <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+          Admin Password
+        </span>
+        <input
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-slate-400 dark:border-slate-800 dark:bg-slate-950 dark:text-white"
+          autoFocus
+        />
+      </label>
+
+      <button
+        type="submit"
+        disabled={isPending || password.length === 0}
+        className="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-slate-950"
+      >
+        {isPending ? "Signing in..." : "Enter Studio"}
+      </button>
+
+      {error ? (
+        <p className="text-sm font-medium text-rose-600 dark:text-rose-400">{error}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/components/studio/StudioLogoutButton.tsx
+++ b/components/studio/StudioLogoutButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+export function StudioLogoutButton() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  async function handleLogout() {
+    await fetch("/api/auth/admin/logout", {
+      method: "POST",
+    });
+
+    startTransition(() => {
+      router.replace("/studio/login");
+      router.refresh();
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void handleLogout()}
+      disabled={isPending}
+      className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-slate-600 transition hover:border-slate-900 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:text-slate-300 dark:hover:border-white dark:hover:text-white"
+    >
+      {isPending ? "Leaving..." : "Logout"}
+    </button>
+  );
+}

--- a/contents/article/260422-tdd-harness-engineering.mdx
+++ b/contents/article/260422-tdd-harness-engineering.mdx
@@ -1,0 +1,180 @@
+---
+title: "AI TDD 기반 하네스 엔지니어링"
+date: "2026-04-22"
+tags: [tdd, automation, orchestration, observability]
+summary: "Codex + Claude 오케스트레이션으로 TDD 자동화 하네스를 구축하고 관찰가능성을 확보한 기술 여정"
+author: Jeanne
+---
+
+## 1. 발단: 감사에서 드러난 관찰가능성의 세 가지 공백
+
+이 프로젝트의 시작점은 이미 돌아가고 있던 TDD 파이프라인이 아니라, 그 파이프라인이 돌린 아티팩트 하나를 감사하는 일이었습니다. 관찰가능성 관점으로 B+ 평가를 매기는 과정에서 세 가지 결함이 구체적으로 드러났습니다.
+
+- `summary.json`에 비용 집계가 없어, 한 번의 TDD 사이클이 돈과 시간을 얼마나 썼는지 사후에 말할 수 없었습니다.
+- coverage 단계가 어떤 이유로 실패했는지 로그만으로는 추적이 불가능했습니다. `skipped_parse_failed` 같은 불친절한 상태 값만 남았습니다.
+- 에이전트가 세션 내부에서 **어떤 파일을 읽고 어떤 도구를 호출했는지** 단위로는 아무것도 기록되어 있지 않았습니다. agent-metrics는 `stdout_chars`, `stderr_chars` 같은 문자 수만 가지고 있었습니다.
+
+TDD 하네스는 결국 "에이전트가 red→green→refactor를 제대로 돌았다"는 주장을 신뢰할 수 있어야 가치가 있는 물건입니다. 주장의 근거가 문자 수뿐이라면, 그 주장을 나중에 누구도 검증할 수 없습니다. 이 감사가 이후 모든 작업의 출발점이 됐고, 이 글은 거기서부터 오케스트레이터가 "단일 에이전트, 단일 세션"까지 내려오는 동안의 기록입니다.
+
+---
+
+## 2. 메트릭 3종 주입과 review-fix 루프의 롤백
+
+첫 번째 조치는 감사 결과에서 나온 결함을 한꺼번에 붙이는 일이었습니다. step별 타이밍·상태를 남기는 `step_metrics`, verify 단계의 전체 출력을 파일로 보존하는 `verify 트랜스크립트`, 그리고 에이전트 실행당 메트릭을 transcript 헤더에 기록하는 `agent-metrics`가 한 묶음으로 들어갔습니다.
+
+변경 대상은 세 파일에 집중됐습니다.
+
+| 파일 | 변경 |
+|---|---|
+| `scripts/ai/orchestrate_tdd.mjs` | step_metrics, decision_log, verify 트랜스크립트, review-fix 루프, review findings 파서 |
+| `scripts/ai/build_agent_contexts.mjs` | reviewer 구조화 출력, review-fix 페이즈 컨텍스트 빌더 |
+| `scripts/ai/run_codex_agent.mjs` | 트랜스크립트에 `<!-- agent-metrics -->` 헤더 |
+
+에이전트 구성도 이때 한 군데 손봤습니다. fix 루프에서 쓰던 `ui-fixer`는 UI 전용 뉘앙스가 남아 있어 일반적인 구현 수정 역할과 어긋났습니다. `implementor`로 교체하면서 `build_agent_contexts.mjs`의 fix 컨텍스트 출력 파일명도 `ui-fixer-fix.md`에서 `implementor-fix.md`로 정리했습니다. 역할 이름이 하는 일과 다르면 로그를 읽는 사람이 계속 머릿속에서 번역해야 한다는 이유였습니다.
+
+토큰 메트릭은 곧바로 뒤따라 붙였습니다. 당시 agent-metrics에는 토큰량이 없었고, `claude --print` 모드에서는 stdout에 토큰 정보가 나오지 않는다는 점이 문제였습니다. `--output-format json`으로 바꾸면 `usage.input_tokens`, `usage.output_tokens`, `total_cost_usd`, `duration_api_ms`가 한꺼번에 나온다는 사실을 확인하고, 이 값을 transcript 헤더에 그대로 남기기 시작했습니다. 이게 다음 감사에서 수치 분석의 기반이 됩니다.
+
+같은 흐름에서 review 결과를 자동으로 fix로 물려주는 루프도 한 번 설계해봤습니다. 단순 재시도 방식과 분기 처리 방식 중 단순 재시도를 고르고 구현에 들어갔지만, 생각보다 건드려야 할 곳이 많아져 다른 작업과 엮이기 시작했습니다. 한 PR에서 너무 많은 변화를 감당하기보다 별도 PR로 끊어내는 편이 낫다고 판단해 롤백했습니다. 메트릭 작업만 남긴 채 마무리했고, 관찰가능성의 바닥은 이 지점에서 한 번 잡혔습니다.
+
+---
+
+## 3. 두 번째 감사: 비용이 가리킨 context 설계의 근본 문제
+
+한참 뒤, 같은 하네스로 돌린 또 다른 아티팩트를 같은 방식으로 감사했습니다. 이번에는 앞서 심어둔 토큰 메트릭 덕분에 정량 분석이 가능했습니다.
+
+| 에이전트 | output | cache_creation | cache_read | 비용 |
+|---------|--------|----------------|------------|------|
+| test-automator | 10,963 | 39,185 | 300,829 | $0.452 |
+| implementor | 4,225 | 26,587 | 455,277 | $0.300 |
+| reviewer | 6,496 | 39,525 | 254,346 | $0.322 |
+| **합계** | **21,684** | **105,297** | **1,010,452** | **$1.074** |
+
+이 사이클이 만들어낸 산출물은 순수함수 6개짜리 파일 2개였고, reviewer는 "do not merge"로 끝을 맺었습니다. $1.07은 명백히 과했습니다. 부수적으로 transcript의 모델명은 `gpt-5.4`로 적혀 있었지만, 비용을 역산하면 Claude Sonnet 요금표와 정확히 맞아떨어졌습니다. 오케스트레이터가 내부적으로 모델 alias를 쓰고 있었다는 사실이 이때 드러났습니다. 라벨이 진실을 반영하지 않는 상태였습니다.
+
+### coverage 파싱 실패의 진짜 원인
+
+감사 과정에서 `skipped_parse_failed`가 11ms 만에 끝난 이유도 함께 추적했습니다. `getPackageAndRelativePath`는 `apps/carbontrack*`, `packages/api`, `packages/utils`만 인식하도록 되어 있었고, `scripts/ai/` 아래 파일은 여기 해당하지 않아 `null`을 반환했습니다. 그러면 `collectCoverageTargets`가 빈 배열을 돌려주면서 coverage 단계가 할 일이 없다고 판단하고 곧바로 종료한 것이었습니다. 상태 이름이 "파싱 실패"라는 오해를 유발했을 뿐, 실제로는 "이 경로를 아예 모른다"가 원인이었습니다. 근본 수정은 `run_targeted_tests.mjs` 구조 변경을 요구해 이번 범위 밖으로 남겼고, 대신 orchestrator 로그에 실제 원인 메시지를 명시하는 것으로 마무리했습니다.
+
+### downstream 보정에서 upstream 설계로
+
+토큰 낭비를 줄이는 첫 번째 시도는 `slimPlanForAgents()`였습니다. 플래너가 만든 단일 플랜을 에이전트별로 필요한 부분만 깎아서 넘기는 함수였습니다. 이 방향이 지적을 받았습니다. 이미 크게 만들어진 플랜을 뒤에서 잘라내는 것은 downstream 보정이고, 제대로 된 해결은 플래너가 처음부터 에이전트 소비 단위로 플랜을 생성하는 것이라는 지적이었습니다.
+
+처음에는 에이전트별로 내용을 분리해서 쓰는 구조도 시도했지만, 플래닝 단계에서 오히려 토큰 비용이 늘어났습니다. 올바른 방식은 **플랜을 한 번만 쓰되 섹션마다 대상 에이전트 마커를 달아두는 것**이었습니다. `build_agent_contexts.mjs`는 마커를 보고 해당 에이전트에게 필요한 섹션만 추출하고, 플래너 프롬프트(`issue-to-pr-prompt.md`) 쪽에는 마커가 포함된 규격화된 템플릿을 강제해 출력 형식이 어긋나지 않게 했습니다. 테스트 시나리오는 아직 구현되지 않은 함수명을 전제할 수 없으므로 함수명이 아닌 **유저/동작 시나리오**로 적도록 같은 프롬프트에 명시해두었습니다.
+
+### 캐시 공유는 트레이드오프였다
+
+초기 개선안에서 2순위로 분류했던 항목이 "implementor와 reviewer가 같은 섹션을 읽으면 캐시 prefix를 공유할 수 있다"였습니다. 논의를 거치면서 이 가정이 무너졌습니다. 에이전트 3개가 순차로 1회씩만 실행되고, TDD 관점에서 에이전트별로 다른 context를 주는 것이 옳다면 prefix가 같을 수가 없습니다. 즉 **context 슬리밍과 캐시 공유는 트레이드오프**였고, 둘 다 갖자는 욕심은 성립하지 않았습니다. transcript의 cache_read 1M 토큰은 에이전트 간 공유가 아니라 한 에이전트 내부에서 API가 여러 번 호출되는 동안 앞선 context가 재사용된 것이었습니다. 개선 우선순위 자체가 잘못 배치되어 있었습니다.
+
+### 진짜 토큰 낭비는 플랜이 아니라 코드 탐색이었다
+
+플랜은 ~2,000 토큰 수준, 전체 비용의 0.2%에 불과했습니다. 초기 개선안 1~3순위가 모두 플랜 관련이었던 것은 진단 자체가 빗나간 경우였습니다. 진짜 원인은 에이전트가 코드베이스를 탐색하면서 읽어 들인 파일들이었습니다. test-automator가 받은 context가 51KB인 것은 related test files 5개 × ~8KB, reviewer가 36KB인 것은 diff가 최대 30KB까지 들어가기 때문이었습니다.
+
+더 구조적인 문제가 여기 맞닿아 있었습니다. implementor는 `sandbox_mode = "workspace-write"`로 전체 codebase 읽기/쓰기가 가능했고, reviewer는 `read-only`지만 전체 codebase를 읽을 수 있었습니다. 에이전트에게 넘기는 context 파일은 "이걸 보라"는 안내일 뿐, 다른 파일 접근을 막는 장치가 아니었습니다. cache_read 455K, 300K 토큰의 실제 출처가 거기였습니다.
+
+하네스 엔지니어링의 전제는 각 에이전트에게 작은 샌드박스를 주고 그 안에서만 작동하게 만드는 것인데, 지금 구현은 그 반대 방향으로 열려 있었습니다. 다만 곧바로 규제를 걸기보다, "에이전트가 실제로 무엇을 읽는지" 데이터를 먼저 쌓기로 했습니다. 사용자의 표현을 그대로 옮기면, **얼마나 읽고 있는지 확인을 해보고 그다음에 규제가 필요한지 생각해보는** 순서였습니다.
+
+이 판단을 실행에 옮긴 것이 `--output-format json`을 `--output-format stream-json`으로 바꾸는 작업이었습니다. stream-json은 최종 결과만 주는 대신 실행 중 모든 tool call 이벤트(Read/Glob/Grep/Bash)를 스트리밍으로 뱉어냅니다. 이 이벤트를 캡처해 file access 감사 로그를 쌓는 자리가 만들어졌습니다.
+
+---
+
+## 4. orchestrate_tdd 전면 리팩터링: 단일 파일에서 순수 함수 아키텍처로
+
+이쯤 되자 관찰가능성 다음으로 `orchestrate_tdd.mjs` 자체가 걸리기 시작했습니다. step_metrics, decision_log, verify 트랜스크립트, review-fix 루프, 파서, git 체크포인트까지 한 파일에 올라타면서 1,000줄에 가까워졌습니다. 세 가지 증상이 함께 쌓였습니다. 변경 지점이 한 파일에 몰려 머지 충돌이 잦았고, 어느 섹션을 건드리고 있는지 한눈에 파악하기 어려웠으며, 무엇보다 **전체 파이프라인 제어 흐름을 위에서 아래로 읽을 수 없었습니다**.
+
+목표 패턴은 명확했습니다. 각 단계는 결과 객체를 반환하고, 오케스트레이터는 흐름 제어만 담당하는 것. 부수효과는 가능한 한 바깥으로 몰아내고 단계 함수는 순수하게 둡니다.
+
+### 1차 분리 — 역할별 파일과 6줄짜리 진입점
+
+`scripts/ai/tdd_orchestration/` 폴더를 만들고 역할별로 쪼갰습니다.
+
+```text
+scripts/ai/
+├── orchestrate_tdd.mjs          ← 6줄 (thin entry point)
+├── logger.mjs                   ← 공유 log()
+├── git_utils.mjs                ← 보안 강화 gitCheckpoint + squash --mixed
+├── review_parser.mjs            ← formatBlockingFindings, sanitizeFindingField
+└── tdd_orchestration/
+    ├── index.mjs                ← main() — 파이프라인 제어 흐름만
+    ├── context.mjs              ← parseArgs, buildConfig, buildPaths
+    ├── timer.mjs                ← createTimer(), applyMetrics()
+    ├── runners.mjs              ← runBuildContexts, runTargetedTests, runCodexAgent, runPnpmTest
+    ├── coverage.mjs             ← parseCoverage, groupCoverageTargets, runCoverageCheck
+    └── steps/
+        ├── writeTests.mjs
+        ├── verifyRed.mjs
+        ├── implement.mjs
+        ├── verifyGreenLoop.mjs
+        └── reviewLoop.mjs
+```
+
+`git_utils.mjs`도 이 과정에서 함께 보강했습니다. `git add -A`를 그대로 두면 의도치 않게 민감한 파일까지 체크포인트로 들어갈 위험이 있어, sensitive 파일을 제외하는 방식으로 `gitCheckpoint`를 바꿨습니다. `squashCheckpoints`는 `--soft`에서 `--mixed`로 전환해, 스쿼시 이후 인덱스 상태가 워킹 디렉토리와 일치하도록 정리했습니다.
+
+### 2차 평가 — 순수 함수 분리가 불완전한 6곳
+
+1차 분리 후에 멈추지 않고 다시 훑었더니, 쪼개기만 했을 뿐 순수 함수로서는 어정쩡한 부분이 여섯 군데 보였습니다.
+
+1. **ctx God Object** — 설정, 경로, 가변 상태, 부수효과 메서드가 한 객체에 섞여 있었습니다.
+2. **step의 summary 직접 변경** — `ctx.summary.all_tests_passing = true` 같은 은닉된 부수효과가 step 안에서 일어났습니다.
+3. **15+ 파라미터 flat destructuring** — `reviewLoop`의 private 함수들이 ctx를 풀었다 다시 묶는 boilerplate를 반복했습니다.
+4. **log() 중복** — `git_utils.mjs`와 `tdd_orchestration/logger.mjs`에 동일한 함수가 두 군데 있었습니다.
+5. **process.exit 산재** — step 함수 내부에서도 종료가 일어나, 흐름이 어디서 끊기는지 예측하기 어려웠습니다.
+6. **coverage subprocess 불일치** — `coverage.mjs`만 `spawnSync`를 직접 호출하고, 나머지는 `runners.mjs`를 경유하는 구조였습니다.
+
+### 2차 수정 — 프레임을 잡다
+
+`context.mjs`를 `buildConfig()`(frozen, 불변 설정)와 `buildPaths()`(frozen, 파생 경로)로 분리하고, `summary`는 `index.mjs` 하나에서만 소유하도록 끌어올렸습니다. step 함수는 `{ result, metrics, ... }`를 반환하는 역할로 좁아졌고, summary 갱신은 오케스트레이터 쪽에서 `applyMetrics(summary, result.metrics)`로 명시적으로 처리했습니다. `process.exit`는 `orchestrate_tdd.mjs`의 `process.exit(main())` 한 줄로 집중시켜, 비정상 종료가 일어날 수 있는 지점을 최소화했습니다. `runners.mjs`에 `runPnpmTest`를 추가해 coverage 쪽도 subprocess를 직접 부르지 않고 같은 통로로 지나가게 만들었습니다.
+
+이 두 번의 정리로 파일 이름만 바꾼 리팩터링이 아니라, **단계는 반환하고 오케스트레이터는 조립한다**는 규칙이 코드에 실제로 박혔습니다.
+
+---
+
+## 5. 단일 세션으로의 전환: 오케스트레이터를 더 멍청하게, 에이전트를 더 자율적으로
+
+리팩터링이 끝나고도 한 가지가 계속 찜찜했습니다. `index.mjs`에는 `write-tests`, `implement`, `review` 세 개의 step 정의가 남아 있었고, step마다 `invokeStep()`이 `runCodexStep()`을 다시 호출하고 있었습니다. 그리고 `run_codex_agent.mjs`는 호출마다 `codex login --with-api-key`와 `codex exec`를 새로 실행했습니다. 외형은 "하나의 에이전트"였지만 실체는 **같은 이름을 공유하는 여러 개의 독립 세션**이었던 셈입니다.
+
+사용자는 오래 전부터 같은 방향을 반복해서 요구해왔습니다. 별도 프로세스로 쪼개지 말 것, 서브에이전트를 흉내 내지 말 것, 하나의 에이전트가 스스로 운전하게 둘 것. 앞선 리팩터링은 멀티 에이전트 구조는 걷어냈지만 step별 별도 세션 호출은 그대로 남겨둔 채 멈춰 있었습니다. "단일 에이전트"까지는 갔지만 "단일 세션"까지는 밀지 못한 상태였습니다.
+
+### step 분기 제거, 단일 진입점
+
+방향을 뒤집어 `index.mjs`를 다시 구성했습니다. step 정의와 step별 `codex exec` 호출을 제거하고, `prompts/README.md` 하나를 세션 진입점으로 삼아 단일 `codex exec` 호출로 갈음했습니다. step별 프롬프트 문서(`write-tests/README.md`, `implement/README.md`, `self-review/README.md`)는 그대로 두되, 에이전트가 한 세션 안에서 이 문서들을 순서대로 읽고 역할을 스스로 전환하게 했습니다. 오케스트레이터는 세션을 시작하고, 끝나기를 기다리고, 결과 파일을 읽습니다. 그것뿐입니다.
+
+이 선택의 트레이드오프는 스스로에게도 분명히 적어두었습니다.
+
+- 얻는 것: 세션 간 context 중복 제거, 구조 단순화, step 간 handoff 비용 제거.
+- 잃는 것: 중간 단계의 가시성, step별 실패 격리, 실패 시 재시도 단위가 step이 아니라 전체 세션으로 커지는 것.
+
+현재 오케스트레이터의 상태에서 이 교환은 가치 있다는 판단이었습니다.
+
+### verifier 논쟁 — "에이전트를 믿는다고 해놓고 실제로는 불신하는 구조"
+
+단일 세션으로 바꾼 직후 구조적 모순이 제기됐습니다. 에이전트가 세션 내부에서 이미 red→green→self-review를 스스로 수행한다고 전제했다면, 오케스트레이터가 그 결과를 `verifyRed`, `verifyGreen`, `verifySelfReview`로 다시 검증하는 것은 에이전트를 믿겠다고 해놓고 실제로는 불신하는 셈이라는 지적이었습니다. 에이전트가 이미 테스트를 돌렸는데 verifier가 왜 따로 필요하냐는 물음이었습니다.
+
+이 질문에 납득이 될 만한 반박이 없었고, 단계별 재검증은 걷어내기로 했습니다. 오케스트레이터는 `tdd_run_report.json`과 `review.json`, 이 두 파일의 `status` 필드와 필수 산출물의 존재 여부만 확인하는 **최소 가드레일**로 축소했습니다. 계약 포맷은 이 두 JSON 파일이고, 별도 파싱 도구 없이 `JSON.parse`로 최소 필드만 읽습니다.
+
+### self-review blocking 판단의 이전
+
+같은 논리를 self-review에도 적용했습니다. 이전에는 오케스트레이터가 review findings를 파싱해 blocking 여부를 판단하고 fix 루프를 돌렸습니다. 단일 세션 구조에서는 맞지 않는 역할 분담이었습니다. 이제 에이전트가 세션 내부에서 self-review 결과를 보고 직접 판단합니다. blocking이 발견되면 스스로 고치고 green을 다시 확인하거나, 고칠 수 없으면 `needs_human`으로 종료합니다. 오케스트레이터는 종료 상태(`completed`, `retry_requested`, `needs_human`) 세 가지만 봅니다. blocking 판단의 위치가 오케스트레이터에서 에이전트 쪽으로 완전히 이전됐습니다.
+
+### 남아 있는 질문 — resume의 의미
+
+여기까지 온 뒤에도 한 가지가 열려 있습니다. verifier 실패 또는 `retry_requested` 시 오케스트레이터가 전체 세션을 재호출하는데, 그 호출의 의미가 "처음부터 다시 하라"인지 "현재 산출물을 읽고 이어서 하라"인지 아직 정해지지 않았습니다. 방향은 후자입니다. 에이전트가 `TDD_OUTPUT_DIR`에 남아 있는 결과를 읽고 실패 지점부터 이어가는 쪽이 단일 세션 철학과 맞습니다. 단 구현 방식은 다음 사이클로 미뤘습니다.
+
+---
+
+## 6. 결과와 배운 점
+
+두 번의 감사와 두 번의 리팩터링을 지나, 하네스는 다음 상태에 와 있습니다.
+
+- 한 번의 사이클이 쓴 **토큰과 비용이 수치로 남습니다**. 그 숫자가 모델 라벨(`gpt-5.4`)의 거짓말을 잡아냈고, 순수함수 두 파일에 $1.07이 타당하지 않다는 판단도 바로 거기서 나왔습니다.
+- `orchestrate_tdd.mjs`는 6줄짜리 진입점이 됐고, 단계는 반환하고 오케스트레이터는 조립한다는 규칙이 코드 구조로 박혔습니다.
+- 하네스는 "단일 에이전트, 다중 세션"에서 "단일 에이전트, 단일 세션"으로 한 칸 더 내려왔습니다. 오케스트레이터는 세션을 띄우고 두 JSON 파일의 `status`만 읽는 최소 가드레일이 됐습니다.
+
+배운 것 중 세 가지가 특히 오래 남을 것 같습니다.
+
+첫째, **context 슬리밍과 캐시 공유는 트레이드오프**다. 둘을 동시에 최적화할 수 있다고 가정한 초기 우선순위는 처음부터 잘못된 문제 정의였습니다. 토큰 낭비의 진짜 출처는 플랜이 아니라 에이전트가 코드베이스를 탐색하며 읽는 파일들이었습니다.
+
+둘째, **downstream 보정은 upstream 설계의 실패를 가린다**. 잘못 만들어진 단일 플랜을 나중에 슬림화하기보다, 플래너가 처음부터 에이전트 소비 단위로 출력하도록 형식을 강제하는 편이 옳았습니다. 잘못된 자리에서 아무리 잘 고쳐도 구조가 바뀌지 않았습니다.
+
+셋째, **"오케스트레이터를 더 멍청하게, 에이전트를 더 자율적으로"는 관찰가능성을 덜 만들자는 말이 아닙니다**. 오히려 가드레일의 자리와 모양을 다시 정의해야 한다는 요구입니다. 이전엔 각 step을 verifier로 감쌌지만, 단일 세션 이후엔 계약 포맷(JSON 파일과 status)만으로 같은 신뢰를 확보해야 합니다. 이 경계가 흐려지면 에이전트를 믿는다고 말하면서 실제로는 단계마다 불신을 새기는 구조로 되돌아가게 됩니다.
+
+아직 남아 있는 숙제는 세 가지입니다. 세션 재호출 시 resume 전략 구현, stream-json 기반 file access 감사 로그의 완성과 그 데이터를 근거로 한 sandbox 제한 결정, 그리고 related test files를 토크나이저 기반으로 슬리밍해 5파일 합산 ~1,500 토큰 상한을 적용하는 작업입니다. 이 숙제들은 이번 글의 범위가 아니라 다음 사이클의 입력입니다.

--- a/contents/article/260422-tdd-harness-orchestration.mdx
+++ b/contents/article/260422-tdd-harness-orchestration.mdx
@@ -1,0 +1,165 @@
+---
+title: "AI TDD 기반 하네스 엔지니어링"
+date: "2026-04-22"
+tags: [tdd, orchestration, harness, refactoring]
+summary: "Codex + Claude를 오케스트레이션해 TDD 사이클(red→green→refactor)을 자동화하는 하네스 파이프라인 구축"
+author: Jeanne
+---
+
+# tdd-harness 개발 스레드
+
+## 발단 — CARSA-5149 관찰가능성 감사
+
+CARSA-5149 아티팩트를 B+ 평가로 감사하면서 구체적 결함이 도출됐다. summary.json에 비용 집계가 없고, coverage 실패 원인이 불명확하며, 에이전트 내부 tool-call 단위 추적이 없다는 세 가지가 핵심이었다. 이 감사가 이후 모든 작업의 출발점이 됐다.
+
+## 1단계 — 메트릭 3종 동시 적용
+
+감사 결과를 바탕으로 step_metrics, verify 트랜스크립트, agent-metrics를 한꺼번에 붙였다. 이 과정에서 ui-fixer가 실제 구현 역할에 맞지 않는다는 판단이 생겨 implementor로 교체했다.
+
+## 2단계 — review-fix 루프 설계와 롤백
+
+review 결과를 자동으로 fix에 물려주는 루프를 설계했다. Option A(단순 재시도)와 Option B(분기 처리) 중 Option A를 선택해 구현을 시작했으나, 예상보다 범위가 커져 롤백을 결정했다. 별도 PR로 분리하기로 했다.
+
+## 3단계 — 토큰 메트릭 추가
+
+`--output-format json` 플래그로 transcript 헤더에 토큰/비용/시간 메트릭을 남기기 시작했다. 이게 이후 CARSA-6454 감사에서 수치 분석의 기반이 됐다.
+
+## 4단계 — run_codex_agent.mjs 단일 책임 분리
+
+파일이 지나치게 많은 역할을 맡고 있어서 4개 함수로 분리했다. 이 리팩터링이 이후 stream-json 감사 기능을 추가할 자리를 만들었다.
+
+## 5단계 — decision_log 제거
+
+step status와 중복된다는 판단으로 decision_log를 제거했다. 관찰가능성을 높이려던 초기 방향과 역설적으로 보이지만, 같은 정보를 두 곳에 유지하는 비용이 더 컸다.
+
+---
+
+## 2026-04-08 — CARSA-6454 감사에서 드러난 context 설계 문제
+
+### 두 번째 관찰가능성 감사
+
+3단계에서 심은 메트릭 덕분에 CARSA-6454 아티팩트의 토큰 사용량을 수치로 분석할 수 있었다.
+
+| 에이전트 | output | cache_creation | cache_read | 비용 |
+|---------|--------|----------------|------------|------|
+| test-automator | 10,963 | 39,185 | 300,829 | $0.452 |
+| implementor | 4,225 | 26,587 | 455,277 | $0.300 |
+| reviewer | 6,496 | 39,525 | 254,346 | $0.322 |
+| **합계** | **21,684** | **105,297** | **1,010,452** | **$1.074** |
+
+산출물은 순수함수 6개짜리 파일 2개였고, reviewer는 "do not merge"를 냈다. $1.07은 명백히 과했다. transcript에 기록된 모델명이 `gpt-5.4`였지만 비용을 역산하면 Claude Sonnet 요금표와 정확히 맞아떨어졌다. orchestrator가 내부적으로 모델 alias를 쓰고 있었던 것.
+
+### coverage 파싱 실패 원인 규명
+
+`skipped_parse_failed`가 11ms 만에 종료된 이유를 추적했다. `getPackageAndRelativePath`는 `apps/carbontrack*`, `packages/api`, `packages/utils`만 인식한다. `scripts/ai/`는 여기 해당하지 않아 `null`을 반환하고, `collectCoverageTargets`가 빈 배열을 돌려줬다. 이름이 오해를 유발했을 뿐, 실제 원인은 인식되지 않는 경로였다. 근본 수정은 `run_targeted_tests.mjs` 구조 변경을 요구해 이번 범위 밖으로 남겼고, orchestrator 로그에 실제 원인 메시지를 명시하는 것으로 마무리했다.
+
+### context slimming — downstream 보정 → upstream 설계
+
+초기에 `slimPlanForAgents()`를 만들어 plan.md를 에이전트별로 깎아서 전달하는 방식으로 구현했다. 그런데 이 접근은 잘못 만들어진 단일 플랜을 나중에 보정하는 것이었다. 올바른 방향은 플래너가 처음부터 에이전트 소비 단위로 플랜을 생성하는 것이다.
+
+처음에는 에이전트별로 내용을 분리해서 쓰는 구조를 시도했지만, 플래닝 단계에서 토큰 비용이 오히려 늘어난다는 지적을 받았다. 올바른 방식은 **플랜을 한 번만 쓰고 섹션에 대상 에이전트 마커를 달아두는 것**이다. `build_agent_contexts.mjs`는 마커를 보고 해당 에이전트에게 필요한 섹션만 추출하고, 플래너 프롬프트(`issue-to-pr-prompt.md`)도 마커가 포함된 규격화된 템플릿에 맞춰 출력하도록 강제했다. 테스트 시나리오는 아직 구현되지 않은 함수를 전제할 수 없으므로 함수명이 아닌 **유저/동작 시나리오**로 작성하도록 명시했다.
+
+### 2순위 캐시 공유 — 실효성 없음으로 결론
+
+implementor와 reviewer가 동일한 섹션을 읽으면 캐시 prefix를 공유할 수 있다고 2순위로 분류했었다. 그런데 에이전트 3개가 순차로 1회씩만 실행되고, TDD 관점에서 에이전트별로 최적화된 context를 주면 내용이 달라지므로 캐시 prefix가 달라진다. **context 슬리밍과 캐시 공유는 트레이드오프 관계**다. transcript의 cache_read 1M 토큰은 에이전트 간 공유가 아니라 에이전트 내부에서 API를 여러 번 호출하는 동안 앞선 context가 재사용된 것이라, 개선 우선순위는 처음부터 없었어야 할 항목이었다.
+
+### 실제 토큰 낭비의 원인
+
+플랜은 ~2,000 토큰으로 전체 비용의 0.2%에 불과했다. 초기 개선안 1~3순위가 모두 플랜 관련이었던 건 잘못된 진단이었다. 진짜 원인은 에이전트가 코드베이스를 탐색하면서 읽은 파일들이었다. test-automator.md가 51KB인 건 related test files 5개 × ~8KB 때문이고, reviewer.md가 36KB인 건 diff 최대 30KB 때문이다.
+
+### 에이전트 샌드박스 설계 문제 제기
+
+현재 implementor는 `sandbox_mode = "workspace-write"`로 전체 codebase 읽기/쓰기가 가능하고, reviewer는 `read-only`지만 역시 전체 codebase를 읽을 수 있다. context 파일은 안내일 뿐 접근을 막지 않는다. cache_read 455K, 300K 토큰의 실제 출처다.
+
+하네스 엔지니어링 원칙은 각 에이전트에게 샌드박스를 제공해 그 안에서만 작동하게 하는 것인데, 지금 구현은 반대다. 규제 필요 여부를 판단하기 전에 에이전트가 실제로 무엇을 읽는지 데이터를 쌓기로 했다.
+
+### 다음 작업
+
+`run_codex_agent.mjs`에서 `--output-format json`을 `--output-format stream-json`으로 전환해 모든 tool call 이벤트를 캡처하는 file access 감사 로그를 구축한다. 감사 데이터를 확보한 뒤 sandbox 제한 여부를 결정하고, 그 다음으로 related test files 토크나이저 기반 슬리밍을 구현한다. 테스트 파일 전체 대신 구조(import, describe/it, mock 선언)만 추출하고 `@anthropic-ai/tokenizer`로 5파일 합산 ~1,500 토큰 상한을 적용하는 방향이다.
+
+---
+
+## 2026-04-09 — orchestrate_tdd 전면 리팩터링과 순수 함수 아키텍처 확립
+
+### 리팩터링 동기
+
+`orchestrate_tdd.mjs` 단일 파일이 1,000줄에 가까워지면서 세 가지 문제가 쌓였다. 잦은 머지 충돌, 어느 섹션을 수정하는지 파악하기 어려운 가독성 저하, 그리고 전체 파이프라인 제어 흐름을 한눈에 읽을 수 없는 상태였다. 사용자가 제시한 to-be 패턴은 명확했다: 각 단계는 결과 객체를 반환하고 오케스트레이터는 흐름 제어만 담당하는 것.
+
+### 1차 분리 — tdd_orchestration/ 폴더 생성
+
+`scripts/ai/tdd_orchestration/` 폴더를 만들고 역할별로 파일을 분리했다:
+
+```text
+scripts/ai/
+├── orchestrate_tdd.mjs          ← 6줄 (thin entry point)
+├── logger.mjs                   ← 공유 log()
+├── git_utils.mjs                ← 보안 강화 gitCheckpoint + squash --mixed
+├── review_parser.mjs            ← formatBlockingFindings, sanitizeFindingField 추가
+│
+└── tdd_orchestration/
+    ├── index.mjs                ← main() — 파이프라인 제어 흐름만
+    ├── context.mjs              ← parseArgs, buildConfig, buildPaths
+    ├── timer.mjs                ← createTimer(), applyMetrics()
+    ├── runners.mjs              ← runBuildContexts, runTargetedTests, runCodexAgent, runPnpmTest
+    ├── coverage.mjs             ← parseCoverage, groupCoverageTargets, runCoverageCheck
+    └── steps/
+        ├── writeTests.mjs       ← Step 1
+        ├── verifyRed.mjs        ← Step 2
+        ├── implement.mjs        ← Step 3
+        ├── verifyGreenLoop.mjs  ← Steps 4+5
+        └── reviewLoop.mjs       ← Step 6
+```
+
+`git_utils.mjs`는 이 과정에서 함께 보강됐다. `git add -A` 대신 sensitive 파일을 제외하는 방식으로 gitCheckpoint를 강화하고, squashCheckpoints는 `--soft`에서 `--mixed`로 전환했다.
+
+### 2차 평가 — 구조적 문제 6가지 도출
+
+1차 분리 후 코드를 정밀 검토하니 순수 함수 분리가 불완전한 부분이 남아 있었다:
+
+1. **ctx God Object**: 설정, 경로, 가변 상태, 부수효과 메서드가 하나의 객체에 혼재
+2. **step의 summary 직접 변경**: `ctx.summary.all_tests_passing = true` 같은 은닉된 부수효과
+3. **15+ 파라미터 flat destructuring**: reviewLoop private 함수들이 ctx를 풀었다 다시 묶는 boilerplate
+4. **log() 중복**: `git_utils.mjs`와 `tdd_orchestration/logger.mjs`에 동일 함수 중복
+5. **process.exit 산재**: step 함수 내부에서도 `process.exit` 호출
+6. **coverage subprocess 불일치**: `coverage.mjs`만 `spawnSync`를 직접 호출, 나머지는 `runners.mjs` 경유
+
+### 2차 수정 — 6가지 해결
+
+`context.mjs`를 `buildConfig()`(frozen, 불변 설정)와 `buildPaths()`(frozen, 파생 경로)로 분리하고 `summary`는 `index.mjs`에서만 관리하게 했다. step 함수는 `{ result, metrics, ... }` 반환만 하고, summary 갱신은 오케스트레이터에서 `applyMetrics(summary, result.metrics)`로 명시적으로 처리했다. `process.exit`는 `orchestrate_tdd.mjs`의 `process.exit(main())`으로 집중했다. `runners.mjs`에 `runPnpmTest`를 추가해 coverage의 subprocess 호출도 통일했다.
+
+---
+
+## 2026-04-21 — 단일 세션 아키텍처로의 전환과 오케스트레이터 역할 재정의
+
+### 재진단 — "단일 에이전트 이름을 쓰는 다중 세션 구조"
+
+04-09 리팩터링으로 `orchestrate_tdd.mjs`는 깔끔해졌지만, 오늘 세션 초반 확인에서 핵심 문제가 드러났다. `index.mjs`에는 `write-tests`, `implement`, `review` 세 개의 step 정의가 있었고, 각 step마다 `invokeStep()`이 `runCodexStep()`을 다시 호출하고 있었다. `run_codex_agent.mjs`는 호출마다 `codex login --with-api-key`와 `codex exec`를 새로 실행했다.
+
+이는 사용자가 여러 세션에 걸쳐 반복적으로 요구해온 방향과 달랐다: "별도 프로세스로 쪼개지 말 것", "서브에이전트 흉내내지 말 것", "하나의 에이전트가 스스로 운전하게 둘 것". 4월 초부터 계속 이 방향을 말해왔는데, 04-09 리팩터링은 멀티 에이전트 구조는 없앴지만 step별 별도 세션 호출은 그대로 남겨둔 채 멈춰 있었다. "단일 에이전트"까지는 갔지만 "단일 세션"까지 밀지 못한 상태였다.
+
+### 구조 전환 — step 분기 제거, 단일 세션 진입점 도입
+
+오케스트레이터가 더 멍청하게, 에이전트가 더 자율적으로, 프롬프트는 더 정적으로 가는 방향으로 `index.mjs`를 재구성했다. step 정의와 step별 `codex exec` 호출을 제거하고, `prompts/README.md` 하나를 세션 진입점으로 삼아 단일 `codex exec` 호출로 대체했다. 에이전트는 그 안에서 `write-tests/README.md` → `implement/README.md` → `self-review/README.md`를 순서대로 읽고, 한 세션 안에서 전체 TDD를 수행하게 됐다. step별 프롬프트 문서는 그대로 유지하되, 에이전트가 세션 내부에서 각 역할로 전환하며 스스로 참조하는 방식이다.
+
+이 전환의 트레이드오프는 명확했다. 얻는 것: 컨텍스트 중복 제거, 구조 단순화, step 간 handoff 비용 제거. 잃는 것: 중간 단계 가시성, step별 실패 격리, 실패 시 재시도 단위가 전체 세션으로 커짐. 현재 오케스트레이터 상태에서는 그 교환이 가치 있다는 판단이었다.
+
+### 철학적 충돌 — verifier 필요성 재검토
+
+단일 세션 전환 직후, 구조적 모순이 제기됐다. 에이전트가 세션 내부에서 이미 red/green/self-review를 스스로 수행한다고 전제했다면, 오케스트레이터가 그 결과를 단계별 verifier로 다시 검증하는 건 에이전트를 믿겠다고 해놓고 실제로는 불신하는 셈이다. 에이전트가 이미 테스트를 돌렸는데 verifier가 왜 필요하냐는 지적이었다.
+
+논의를 거쳐 `verifyRed / verifyGreen / verifySelfReview` 같은 단계별 재검증은 없애기로 했다. 오케스트레이터는 `tdd_run_report.json`과 `review.json`의 `status` 필드와 필수 산출물 존재 여부만 확인하는 최소 가드레일로 축소했다. 계약 포맷은 이 두 JSON 파일이고, 별도 파싱 도구 없이 `JSON.parse`로 최소 필드만 읽는다.
+
+### self-review blocking의 책임 이전
+
+review blocking 처리 방식도 같은 맥락에서 정리했다. 에이전트가 세션 내부에서 self-review 결과를 보고 직접 판단한다. blocking을 발견하면 스스로 수정 후 green을 재확인하거나, 고칠 수 없으면 `needs_human`으로 종료한다. 오케스트레이터는 종료 상태(`completed`, `retry_requested`, `needs_human`)만 본다. `verifySelfReview` 호출 의존이 제거되고, blocking 판단이 오케스트레이터에서 에이전트 쪽으로 완전히 이전됐다.
+
+### 미결 — 세션 재호출 시 resume 전략
+
+오늘 세션이 열린 채로 끝난 문제가 하나 있다. verifier 실패 또는 `retry_requested` 시 오케스트레이터가 전체 세션을 재호출하는데, 그 의미가 "처음부터 다시 하라"인지 "현재 산출물을 읽고 이어서 하라"인지 아직 결정되지 않았다. 올바른 방향은 resume다. 에이전트가 `TDD_OUTPUT_DIR`에 남아 있는 결과를 읽고 실패 지점부터 이어가는 것이지만, 구현 방식은 다음 세션으로 미뤄졌다.
+
+## 미결 과제
+
+- 세션 재호출 시 resume 전략 구현 (처음부터 재실행 vs. 산출물 읽고 이어서)
+- stream-json 기반 file access 감사 로그 완성 후 sandbox 제한 여부 결정
+- related test files 토크나이저 기반 슬리밍 (`@anthropic-ai/tokenizer`, 5파일 합산 ~1,500 토큰 상한)
+- `getPackageAndRelativePath`에 `scripts/ai/` 경로 추가 (coverage 근본 해결)

--- a/db/client.ts
+++ b/db/client.ts
@@ -1,0 +1,28 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { requireDatabaseUrl } from "@/lib/env";
+import * as schema from "@/db/schema";
+
+declare global {
+  var jeanneLogPool: Pool | undefined;
+}
+
+function createPool() {
+  return new Pool({
+    connectionString: requireDatabaseUrl(),
+  });
+}
+
+export function getPool() {
+  if (!global.jeanneLogPool) {
+    global.jeanneLogPool = createPool();
+  }
+
+  return global.jeanneLogPool;
+}
+
+export function getDb() {
+  return drizzle(getPool(), { schema });
+}
+
+export type Database = ReturnType<typeof getDb>;

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,0 +1,217 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export const articleStatusEnum = pgEnum("article_status", [
+  "draft",
+  "in_review",
+  "regenerating",
+  "published",
+  "archived",
+]);
+
+export const articleSourceTypeEnum = pgEnum("article_source_type", [
+  "weekly",
+  "project",
+  "manual",
+  "regenerated",
+]);
+
+export const reviewCommentStatusEnum = pgEnum("review_comment_status", [
+  "open",
+  "resolved",
+  "dismissed",
+]);
+
+export const regenerationJobStatusEnum = pgEnum("regeneration_job_status", [
+  "queued",
+  "running",
+  "failed",
+  "completed",
+]);
+
+export const regenerationJobTypeEnum = pgEnum("regeneration_job_type", [
+  "initial_draft",
+  "regenerate",
+]);
+
+export const publicationEventTypeEnum = pgEnum("publication_event_type", [
+  "published",
+  "unpublished",
+  "archived",
+]);
+
+export const adminUsers = pgTable(
+  "admin_users",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    githubUserId: varchar("github_user_id", { length: 64 }).notNull(),
+    email: varchar("email", { length: 255 }),
+    role: varchar("role", { length: 32 }).notNull().default("admin"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    githubUserIdIdx: uniqueIndex("admin_users_github_user_id_idx").on(table.githubUserId),
+    emailIdx: uniqueIndex("admin_users_email_idx").on(table.email),
+  })
+);
+
+export const articles = pgTable(
+  "articles",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    slug: varchar("slug", { length: 255 }).notNull(),
+    status: articleStatusEnum("status").notNull().default("draft"),
+    title: text("title").notNull(),
+    summary: text("summary").notNull().default(""),
+    currentVersionId: uuid("current_version_id"),
+    publishedVersionId: uuid("published_version_id"),
+    createdBy: uuid("created_by").references(() => adminUsers.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+  },
+  (table) => ({
+    slugIdx: uniqueIndex("articles_slug_idx").on(table.slug),
+    statusUpdatedAtIdx: index("articles_status_updated_at_idx").on(table.status, table.updatedAt),
+    publishedAtIdx: index("articles_published_at_idx").on(table.publishedAt),
+  })
+);
+
+export const articleVersions = pgTable(
+  "article_versions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    articleId: uuid("article_id")
+      .notNull()
+      .references(() => articles.id, { onDelete: "cascade" }),
+    versionNumber: integer("version_number").notNull(),
+    sourceType: articleSourceTypeEnum("source_type").notNull().default("manual"),
+    sourceLabel: varchar("source_label", { length: 255 }),
+    mdxSource: text("mdx_source").notNull(),
+    plainTextSnapshot: text("plain_text_snapshot").notNull(),
+    lineIndex: jsonb("line_index").$type<LineIndexEntry[]>().notNull().default([]),
+    generationPromptSnapshot: text("generation_prompt_snapshot"),
+    generationContext: jsonb("generation_context").$type<Record<string, unknown>>(),
+    modelName: varchar("model_name", { length: 128 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    articleVersionIdx: uniqueIndex("article_versions_article_version_idx").on(
+      table.articleId,
+      table.versionNumber
+    ),
+    articleCreatedAtIdx: index("article_versions_article_created_at_idx").on(
+      table.articleId,
+      table.createdAt
+    ),
+  })
+);
+
+export const reviewComments = pgTable(
+  "review_comments",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    articleVersionId: uuid("article_version_id")
+      .notNull()
+      .references(() => articleVersions.id, { onDelete: "cascade" }),
+    startLine: integer("start_line").notNull(),
+    endLine: integer("end_line").notNull(),
+    selectedText: text("selected_text").notNull(),
+    body: text("body").notNull(),
+    status: reviewCommentStatusEnum("status").notNull().default("open"),
+    createdBy: uuid("created_by").references(() => adminUsers.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    articleVersionRangeIdx: index("review_comments_article_version_range_idx").on(
+      table.articleVersionId,
+      table.startLine,
+      table.endLine
+    ),
+    statusIdx: index("review_comments_status_idx").on(table.status),
+  })
+);
+
+export const regenerationJobs = pgTable(
+  "regeneration_jobs",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    articleId: uuid("article_id")
+      .notNull()
+      .references(() => articles.id, { onDelete: "cascade" }),
+    baseVersionId: uuid("base_version_id").references(() => articleVersions.id, {
+      onDelete: "set null",
+    }),
+    status: regenerationJobStatusEnum("status").notNull().default("queued"),
+    jobType: regenerationJobTypeEnum("job_type").notNull().default("regenerate"),
+    inputPayload: jsonb("input_payload").$type<Record<string, unknown>>().notNull().default({}),
+    resultVersionId: uuid("result_version_id").references(() => articleVersions.id, {
+      onDelete: "set null",
+    }),
+    errorMessage: text("error_message"),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    lockedAt: timestamp("locked_at", { withTimezone: true }),
+    workerId: varchar("worker_id", { length: 255 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    statusCreatedAtIdx: index("regeneration_jobs_status_created_at_idx").on(
+      table.status,
+      table.createdAt
+    ),
+    articleStatusIdx: index("regeneration_jobs_article_status_idx").on(table.articleId, table.status),
+  })
+);
+
+export const publicationEvents = pgTable(
+  "publication_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    articleId: uuid("article_id")
+      .notNull()
+      .references(() => articles.id, { onDelete: "cascade" }),
+    fromVersionId: uuid("from_version_id").references(() => articleVersions.id, {
+      onDelete: "set null",
+    }),
+    toVersionId: uuid("to_version_id").references(() => articleVersions.id, {
+      onDelete: "set null",
+    }),
+    eventType: publicationEventTypeEnum("event_type").notNull(),
+    actor: varchar("actor", { length: 255 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    articleCreatedAtIdx: index("publication_events_article_created_at_idx").on(
+      table.articleId,
+      table.createdAt
+    ),
+  })
+);
+
+export type LineIndexEntry = {
+  lineNumber: number;
+  startOffset: number;
+  endOffset: number;
+  content: string;
+};
+
+export type InsertArticle = typeof articles.$inferInsert;
+export type SelectArticle = typeof articles.$inferSelect;
+export type InsertArticleVersion = typeof articleVersions.$inferInsert;
+export type SelectArticleVersion = typeof articleVersions.$inferSelect;
+export type InsertReviewComment = typeof reviewComments.$inferInsert;
+export type SelectReviewComment = typeof reviewComments.$inferSelect;
+export type InsertRegenerationJob = typeof regenerationJobs.$inferInsert;
+export type SelectRegenerationJob = typeof regenerationJobs.$inferSelect;

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,17 @@
+import "dotenv/config";
+import { defineConfig } from "drizzle-kit";
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required to run Drizzle commands.");
+}
+
+export default defineConfig({
+  schema: "./db/schema.ts",
+  out: "./drizzle",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: databaseUrl,
+  },
+});

--- a/lib/api/internal.ts
+++ b/lib/api/internal.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { requireInternalApiToken } from "@/lib/env";
+
+export function assertInternalRequest(request: NextRequest) {
+  const authorization = request.headers.get("authorization");
+  const expectedToken = requireInternalApiToken();
+
+  if (!authorization?.startsWith("Bearer ")) {
+    throw new Error("Missing bearer token.");
+  }
+
+  const token = authorization.replace("Bearer ", "").trim();
+
+  if (token !== expectedToken) {
+    throw new Error("Invalid internal API token.");
+  }
+}

--- a/lib/api/internal.ts
+++ b/lib/api/internal.ts
@@ -15,3 +15,13 @@ export function assertInternalRequest(request: NextRequest) {
     throw new Error("Invalid internal API token.");
   }
 }
+
+export function getInternalWorkerId(request: NextRequest) {
+  const workerId = request.headers.get("x-worker-id")?.trim();
+
+  if (!workerId) {
+    throw new Error("Missing worker id.");
+  }
+
+  return workerId;
+}

--- a/lib/auth/admin-session.ts
+++ b/lib/auth/admin-session.ts
@@ -1,0 +1,110 @@
+import { cookies } from "next/headers";
+import { NextRequest } from "next/server";
+import { SignJWT, jwtVerify } from "jose";
+import { env } from "@/lib/env";
+
+const ADMIN_SESSION_COOKIE = "jeanne_log_admin_session";
+const ADMIN_SESSION_DURATION_SECONDS = 60 * 60 * 24 * 7;
+
+function getAdminPassword() {
+  if (!env.ADMIN_PASSWORD) {
+    throw new Error("ADMIN_PASSWORD is not configured.");
+  }
+
+  return env.ADMIN_PASSWORD;
+}
+
+function getAdminSessionSecret() {
+  if (!env.ADMIN_SESSION_SECRET) {
+    throw new Error("ADMIN_SESSION_SECRET is not configured.");
+  }
+
+  return env.ADMIN_SESSION_SECRET;
+}
+
+function getSecretKey() {
+  return new TextEncoder().encode(getAdminSessionSecret());
+}
+
+export function verifyAdminPassword(password: string) {
+  return password === getAdminPassword();
+}
+
+export async function createAdminSessionToken() {
+  return new SignJWT({ role: "admin" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(`${ADMIN_SESSION_DURATION_SECONDS}s`)
+    .sign(getSecretKey());
+}
+
+export async function verifyAdminSessionToken(token: string) {
+  try {
+    const result = await jwtVerify(token, getSecretKey(), {
+      algorithms: ["HS256"],
+    });
+
+    return result.payload.role === "admin";
+  } catch {
+    return false;
+  }
+}
+
+export async function createAdminSessionCookie() {
+  const token = await createAdminSessionToken();
+
+  return {
+    name: ADMIN_SESSION_COOKIE,
+    value: token,
+    options: {
+      httpOnly: true,
+      sameSite: "lax" as const,
+      secure: env.NODE_ENV === "production",
+      path: "/",
+      maxAge: ADMIN_SESSION_DURATION_SECONDS,
+    },
+  };
+}
+
+export function clearAdminSessionCookie() {
+  return {
+    name: ADMIN_SESSION_COOKIE,
+    value: "",
+    options: {
+      httpOnly: true,
+      sameSite: "lax" as const,
+      secure: env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 0,
+    },
+  };
+}
+
+export async function isAdminSessionAuthenticated() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(ADMIN_SESSION_COOKIE)?.value;
+
+  if (!token) {
+    return false;
+  }
+
+  return verifyAdminSessionToken(token);
+}
+
+export async function assertAdminRequest(request: NextRequest) {
+  const token = request.cookies.get(ADMIN_SESSION_COOKIE)?.value;
+
+  if (!token) {
+    throw new Error("Admin session is missing.");
+  }
+
+  const isValid = await verifyAdminSessionToken(token);
+
+  if (!isValid) {
+    throw new Error("Admin session is invalid.");
+  }
+}
+
+export function getAdminSessionCookieName() {
+  return ADMIN_SESSION_COOKIE;
+}

--- a/lib/content/drafts.ts
+++ b/lib/content/drafts.ts
@@ -6,6 +6,7 @@ import {
   calculateReadTime,
   createPlainTextSnapshot,
 } from "@/lib/content/posts";
+import { UpdateDraftInput } from "@/lib/validators/drafts";
 
 type CreateDraftInput = {
   slug: string;
@@ -107,6 +108,95 @@ export async function createOrUpdateDraft(
     await tx
       .update(articles)
       .set({
+        currentVersionId: insertedVersion[0].versionId,
+        updatedAt: now,
+        status: "draft",
+      })
+      .where(eq(articles.id, articleId));
+
+    return {
+      articleId,
+      versionId: insertedVersion[0].versionId,
+      versionNumber: nextVersionNumber,
+    };
+  });
+}
+
+export async function createManualDraftVersion(
+  db: Database,
+  articleId: string,
+  input: UpdateDraftInput
+) {
+  const now = new Date();
+  const plainTextSnapshot = createPlainTextSnapshot(input.mdxSource);
+  const lineIndex = buildLineIndex(input.mdxSource);
+
+  return db.transaction(async (tx) => {
+    const articleRows = await tx
+      .select()
+      .from(articles)
+      .where(eq(articles.id, articleId))
+      .limit(1);
+
+    if (articleRows.length === 0) {
+      throw new Error("Draft not found.");
+    }
+
+    const article = articleRows[0];
+
+    if (!article.currentVersionId) {
+      throw new Error("Draft has no current version.");
+    }
+
+    const currentVersionRows = await tx
+      .select()
+      .from(articleVersions)
+      .where(eq(articleVersions.id, article.currentVersionId))
+      .limit(1);
+
+    if (currentVersionRows.length === 0) {
+      throw new Error("Current draft version not found.");
+    }
+
+    const currentVersion = currentVersionRows[0];
+    const latestVersion = await tx
+      .select({
+        versionNumber: articleVersions.versionNumber,
+      })
+      .from(articleVersions)
+      .where(eq(articleVersions.articleId, articleId))
+      .orderBy(desc(articleVersions.versionNumber))
+      .limit(1);
+
+    const nextVersionNumber = (latestVersion[0]?.versionNumber ?? 0) + 1;
+
+    const insertedVersion = await tx
+      .insert(articleVersions)
+      .values({
+        articleId,
+        versionNumber: nextVersionNumber,
+        sourceType: "manual",
+        sourceLabel: "studio-editor",
+        mdxSource: input.mdxSource,
+        plainTextSnapshot,
+        lineIndex,
+        generationPromptSnapshot: currentVersion.generationPromptSnapshot,
+        generationContext: {
+          ...currentVersion.generationContext,
+          readTime: calculateReadTime(plainTextSnapshot),
+          editor: "studio",
+        },
+        modelName: currentVersion.modelName,
+      })
+      .returning({
+        versionId: articleVersions.id,
+      });
+
+    await tx
+      .update(articles)
+      .set({
+        title: input.title,
+        summary: input.summary,
         currentVersionId: insertedVersion[0].versionId,
         updatedAt: now,
         status: "draft",

--- a/lib/content/drafts.ts
+++ b/lib/content/drafts.ts
@@ -1,0 +1,122 @@
+import { desc, eq } from "drizzle-orm";
+import { Database } from "@/db/client";
+import { articleVersions, articles } from "@/db/schema";
+import {
+  buildLineIndex,
+  calculateReadTime,
+  createPlainTextSnapshot,
+} from "@/lib/content/posts";
+
+type CreateDraftInput = {
+  slug: string;
+  title: string;
+  summary: string;
+  mdxSource: string;
+  sourceType: "weekly" | "project" | "manual" | "regenerated";
+  sourceLabel?: string;
+  modelName?: string;
+  author?: string;
+  tags?: string[];
+  generationPromptSnapshot?: string;
+  generationContext?: Record<string, unknown>;
+};
+
+export async function createOrUpdateDraft(
+  db: Database,
+  input: CreateDraftInput
+) {
+  const now = new Date();
+  const plainTextSnapshot = createPlainTextSnapshot(input.mdxSource);
+  const lineIndex = buildLineIndex(input.mdxSource);
+  const readTime = calculateReadTime(plainTextSnapshot);
+
+  return db.transaction(async (tx) => {
+    const existingArticle = await tx
+      .select()
+      .from(articles)
+      .where(eq(articles.slug, input.slug))
+      .limit(1);
+
+    if (existingArticle[0]?.status === "published") {
+      throw new Error(`Cannot overwrite published article with slug: ${input.slug}`);
+    }
+
+    let articleId = existingArticle[0]?.id;
+
+    if (!articleId) {
+      const inserted = await tx
+        .insert(articles)
+        .values({
+          slug: input.slug,
+          status: "draft",
+          title: input.title,
+          summary: input.summary,
+          updatedAt: now,
+        })
+        .returning({
+          id: articles.id,
+        });
+
+      articleId = inserted[0].id;
+    } else {
+      await tx
+        .update(articles)
+        .set({
+          title: input.title,
+          summary: input.summary,
+          status: input.sourceType === "regenerated" ? "regenerating" : "draft",
+          updatedAt: now,
+        })
+        .where(eq(articles.id, articleId));
+    }
+
+    const latestVersion = await tx
+      .select({
+        versionNumber: articleVersions.versionNumber,
+      })
+      .from(articleVersions)
+      .where(eq(articleVersions.articleId, articleId))
+      .orderBy(desc(articleVersions.versionNumber))
+      .limit(1);
+
+    const nextVersionNumber = (latestVersion[0]?.versionNumber ?? 0) + 1;
+
+    const insertedVersion = await tx
+      .insert(articleVersions)
+      .values({
+        articleId,
+        versionNumber: nextVersionNumber,
+        sourceType: input.sourceType,
+        sourceLabel: input.sourceLabel,
+        mdxSource: input.mdxSource,
+        plainTextSnapshot,
+        lineIndex,
+        generationPromptSnapshot: input.generationPromptSnapshot,
+        generationContext: {
+          ...input.generationContext,
+          author: input.author ?? "Jeanne",
+          tags: input.tags ?? [],
+          readTime,
+        },
+        modelName: input.modelName,
+      })
+      .returning({
+        versionId: articleVersions.id,
+      });
+
+    await tx
+      .update(articles)
+      .set({
+        currentVersionId: insertedVersion[0].versionId,
+        updatedAt: now,
+        status: "draft",
+      })
+      .where(eq(articles.id, articleId));
+
+    return {
+      articleId,
+      versionId: insertedVersion[0].versionId,
+      versionNumber: nextVersionNumber,
+    };
+  });
+}

--- a/lib/content/posts.ts
+++ b/lib/content/posts.ts
@@ -1,0 +1,69 @@
+import matter from "gray-matter";
+import type { LineIndexEntry } from "@/db/schema";
+
+type ParsedPostMetadata = {
+  title: string;
+  summary: string;
+  author: string;
+  date: string;
+  tags: string[];
+  readTime?: string;
+};
+
+export function parsePostFile(fileContents: string): {
+  metadata: ParsedPostMetadata;
+  body: string;
+} {
+  const { data, content } = matter(fileContents);
+
+  return {
+    metadata: {
+      title: typeof data.title === "string" ? data.title : "",
+      summary: typeof data.summary === "string" ? data.summary : "",
+      author: typeof data.author === "string" ? data.author : "Admin",
+      date:
+        typeof data.date === "string"
+          ? data.date
+          : new Date().toISOString().split("T")[0],
+      tags: Array.isArray(data.tags)
+        ? data.tags.filter((tag): tag is string => typeof tag === "string")
+        : ["General"],
+      readTime: typeof data.readTime === "string" ? data.readTime : undefined,
+    },
+    body: content.trim(),
+  };
+}
+
+export function calculateReadTime(text: string): string {
+  const wpm = 200;
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const time = Math.max(1, Math.ceil(words / wpm));
+  return `${time} min read`;
+}
+
+export function buildLineIndex(source: string): LineIndexEntry[] {
+  const normalized = source.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  const entries: LineIndexEntry[] = [];
+  let cursor = 0;
+
+  lines.forEach((line, index) => {
+    const startOffset = cursor;
+    const endOffset = cursor + line.length;
+
+    entries.push({
+      lineNumber: index + 1,
+      startOffset,
+      endOffset,
+      content: line,
+    });
+
+    cursor = endOffset + 1;
+  });
+
+  return entries;
+}
+
+export function createPlainTextSnapshot(source: string) {
+  return source.replace(/\r\n/g, "\n").trim();
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+const environmentSchema = z.object({
+  DATABASE_URL: z.string().min(1).optional(),
+  INTERNAL_API_TOKEN: z.string().min(1).optional(),
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+});
+
+const parsedEnvironment = environmentSchema.safeParse(process.env);
+
+if (!parsedEnvironment.success) {
+  throw new Error(`Invalid environment configuration: ${parsedEnvironment.error.message}`);
+}
+
+export const env = parsedEnvironment.data;
+
+export function requireDatabaseUrl() {
+  if (!env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is not configured.");
+  }
+
+  return env.DATABASE_URL;
+}
+
+export function requireInternalApiToken() {
+  if (!env.INTERNAL_API_TOKEN) {
+    throw new Error("INTERNAL_API_TOKEN is not configured.");
+  }
+
+  return env.INTERNAL_API_TOKEN;
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 const environmentSchema = z.object({
   DATABASE_URL: z.string().min(1).optional(),
   INTERNAL_API_TOKEN: z.string().min(1).optional(),
+  ADMIN_PASSWORD: z.string().min(1).optional(),
+  ADMIN_SESSION_SECRET: z.string().min(32).optional(),
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
 });
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -14,6 +14,10 @@ if (!parsedEnvironment.success) {
 
 export const env = parsedEnvironment.data;
 
+export function hasDatabaseUrl() {
+  return Boolean(env.DATABASE_URL);
+}
+
 export function requireDatabaseUrl() {
   if (!env.DATABASE_URL) {
     throw new Error("DATABASE_URL is not configured.");

--- a/lib/validators/comments.ts
+++ b/lib/validators/comments.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const createCommentSchema = z.object({
+  articleVersionId: z.string().uuid(),
+  startLine: z.number().int().positive(),
+  endLine: z.number().int().positive(),
+  selectedText: z.string().min(1),
+  body: z.string().min(1),
+});
+
+export const updateCommentSchema = z
+  .object({
+    body: z.string().min(1).optional(),
+    status: z.enum(["open", "resolved", "dismissed"]).optional(),
+  })
+  .refine((value) => value.body !== undefined || value.status !== undefined, {
+    message: "At least one field must be provided.",
+  });
+
+export type CreateCommentInput = z.infer<typeof createCommentSchema>;
+export type UpdateCommentInput = z.infer<typeof updateCommentSchema>;

--- a/lib/validators/drafts.ts
+++ b/lib/validators/drafts.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const updateDraftSchema = z.object({
+  title: z.string().min(1),
+  summary: z.string().default(""),
+  mdxSource: z.string().min(1),
+});
+
+export type UpdateDraftInput = z.infer<typeof updateDraftSchema>;

--- a/lib/validators/internal-drafts.ts
+++ b/lib/validators/internal-drafts.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const internalDraftSchema = z.object({
+  slug: z.string().min(1).max(255),
+  title: z.string().min(1),
+  summary: z.string().default(""),
+  mdxSource: z.string().min(1),
+  sourceType: z.enum(["weekly", "project", "manual", "regenerated"]).default("manual"),
+  sourceLabel: z.string().max(255).optional(),
+  modelName: z.string().max(128).optional(),
+  author: z.string().max(255).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  generationPromptSnapshot: z.string().optional(),
+  generationContext: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type InternalDraftInput = z.infer<typeof internalDraftSchema>;

--- a/lib/validators/internal-jobs.ts
+++ b/lib/validators/internal-jobs.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const completeRegenerationJobSchema = z.object({
+  title: z.string().min(1),
+  summary: z.string().default(""),
+  mdxSource: z.string().min(1),
+  modelName: z.string().max(128).optional(),
+  author: z.string().max(255).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  generationPromptSnapshot: z.string().optional(),
+  generationContext: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const failRegenerationJobSchema = z.object({
+  errorMessage: z.string().min(1),
+});
+
+export type CompleteRegenerationJobInput = z.infer<typeof completeRegenerationJobSchema>;
+export type FailRegenerationJobInput = z.infer<typeof failRegenerationJobSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,26 +9,33 @@
       "version": "0.0.0",
       "dependencies": {
         "@next/third-parties": "^16.1.6",
+        "dotenv": "^17.4.2",
+        "drizzle-orm": "^0.45.2",
         "fs": "^0.0.1-security",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.555.0",
         "next": "^16.0.7",
         "next-mdx-remote": "^6.0.0",
         "path": "^0.12.7",
+        "pg": "^8.20.0",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.17",
         "@tailwindcss/typography": "^0.5.19",
         "@types/node": "^22.14.0",
+        "@types/pg": "^8.20.0",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.22",
+        "drizzle-kit": "^0.31.10",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
+        "tsx": "^4.21.0",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
       }
@@ -306,6 +313,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
@@ -313,6 +327,442 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2079,9 +2529,21 @@
       "version": "22.19.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -2305,6 +2767,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001757",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
@@ -2522,6 +2991,159 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/drizzle-kit": {
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "tsx": "^4.21.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2854,6 +3476,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -4460,6 +5095,95 @@
         "util": "^0.10.3"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4536,6 +5260,45 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -4737,6 +5500,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -4932,6 +5705,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -4939,6 +5733,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -5127,6 +5930,510 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -5144,7 +6451,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -5450,6 +6757,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -5469,6 +6785,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "drizzle-orm": "^0.45.2",
         "fs": "^0.0.1-security",
         "gray-matter": "^4.0.3",
+        "jose": "^6.2.2",
         "lucide-react": "^0.555.0",
         "next": "^16.0.7",
         "next-mdx-remote": "^6.0.0",
@@ -3706,6 +3707,15 @@
       "dev": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:import:legacy": "node --import tsx ./scripts/import-legacy-posts.ts"
   },
   "dependencies": {
     "@next/third-parties": "^16.1.6",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "drizzle-orm": "^0.45.2",
     "fs": "^0.0.1-security",
     "gray-matter": "^4.0.3",
+    "jose": "^6.2.2",
     "lucide-react": "^0.555.0",
     "next": "^16.0.7",
     "next-mdx-remote": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -8,30 +8,41 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky"
+    "prepare": "husky",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@next/third-parties": "^16.1.6",
+    "dotenv": "^17.4.2",
+    "drizzle-orm": "^0.45.2",
     "fs": "^0.0.1-security",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.555.0",
     "next": "^16.0.7",
     "next-mdx-remote": "^6.0.0",
     "path": "^0.12.7",
+    "pg": "^8.20.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.17",
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^22.14.0",
+    "@types/pg": "^8.20.0",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.22",
+    "drizzle-kit": "^0.31.10",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
+    "tsx": "^4.21.0",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
   },

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  getAdminSessionCookieName,
+  verifyAdminSessionToken,
+} from "@/lib/auth/admin-session";
+
+const STUDIO_LOGIN_PATH = "/studio/login";
+
+export async function proxy(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+
+  if (pathname === STUDIO_LOGIN_PATH) {
+    const token = request.cookies.get(getAdminSessionCookieName())?.value;
+    if (token && (await verifyAdminSessionToken(token))) {
+      return NextResponse.redirect(new URL("/studio/drafts", request.url));
+    }
+
+    return NextResponse.next();
+  }
+
+  const isProtectedStudioPath = pathname.startsWith("/studio");
+  const isProtectedAdminApiPath = pathname.startsWith("/api/admin");
+
+  if (!isProtectedStudioPath && !isProtectedAdminApiPath) {
+    return NextResponse.next();
+  }
+
+  const token = request.cookies.get(getAdminSessionCookieName())?.value;
+  const isAuthenticated = token ? await verifyAdminSessionToken(token) : false;
+
+  if (isAuthenticated) {
+    return NextResponse.next();
+  }
+
+  if (isProtectedAdminApiPath) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Admin authentication required.",
+      },
+      { status: 401 }
+    );
+  }
+
+  const loginUrl = new URL(STUDIO_LOGIN_PATH, request.url);
+  loginUrl.searchParams.set("next", `${pathname}${search}`);
+
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ["/studio/:path*", "/api/admin/:path*"],
+};

--- a/scripts/import-legacy-posts.ts
+++ b/scripts/import-legacy-posts.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import path from "node:path";
+import { and, desc, eq } from "drizzle-orm";
+import { getDb } from "../db/client";
+import { articleVersions, articles } from "../db/schema";
+import {
+  buildLineIndex,
+  calculateReadTime,
+  createPlainTextSnapshot,
+  parsePostFile,
+} from "../lib/content/posts";
+
+const articleDirectory = path.join(process.cwd(), "contents", "article");
+const dryRun = process.argv.includes("--dry-run");
+
+function toPublishedDate(dateValue: string) {
+  const parsed = new Date(dateValue);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date();
+  }
+
+  return parsed;
+}
+
+async function upsertLegacyPost(fileName: string) {
+  const slug = fileName.replace(/\.mdx?$/, "");
+  const filePath = path.join(articleDirectory, fileName);
+  const fileContents = fs.readFileSync(filePath, "utf8");
+  const { metadata, body } = parsePostFile(fileContents);
+  const publishedAt = toPublishedDate(metadata.date);
+  const summary = metadata.summary || body.slice(0, 150).trim();
+  const plainTextSnapshot = createPlainTextSnapshot(body);
+  const lineIndex = buildLineIndex(body);
+
+  if (dryRun) {
+    return {
+      slug,
+      created: false,
+      updated: false,
+      dryRun: true,
+    };
+  }
+
+  const db = getDb();
+
+  return db.transaction(async (tx) => {
+    const existingArticle = await tx
+      .select()
+      .from(articles)
+      .where(eq(articles.slug, slug))
+      .limit(1);
+
+    let articleId = existingArticle[0]?.id;
+    let created = false;
+    let updated = false;
+
+    if (!articleId) {
+      const insertedArticle = await tx
+        .insert(articles)
+        .values({
+          slug,
+          status: "published",
+          title: metadata.title || slug,
+          summary,
+          publishedAt,
+          createdAt: publishedAt,
+          updatedAt: new Date(),
+        })
+        .returning({ id: articles.id });
+
+      articleId = insertedArticle[0].id;
+      created = true;
+    } else {
+      await tx
+        .update(articles)
+        .set({
+          status: "published",
+          title: metadata.title || slug,
+          summary,
+          publishedAt,
+          updatedAt: new Date(),
+        })
+        .where(eq(articles.id, articleId));
+
+      updated = true;
+    }
+
+    const existingVersion = await tx
+      .select()
+      .from(articleVersions)
+      .where(and(eq(articleVersions.articleId, articleId), eq(articleVersions.sourceLabel, fileName)))
+      .limit(1);
+
+    let versionId = existingVersion[0]?.id;
+
+    if (!versionId) {
+      const latestVersion = await tx
+        .select({
+          versionNumber: articleVersions.versionNumber,
+        })
+        .from(articleVersions)
+        .where(eq(articleVersions.articleId, articleId))
+        .orderBy(desc(articleVersions.versionNumber))
+        .limit(1);
+
+      const nextVersionNumber = (latestVersion[0]?.versionNumber ?? 0) + 1;
+
+      const insertedVersion = await tx
+        .insert(articleVersions)
+        .values({
+          articleId,
+          versionNumber: nextVersionNumber,
+          sourceType: "manual",
+          sourceLabel: fileName,
+          mdxSource: body,
+          plainTextSnapshot,
+          lineIndex,
+          generationContext: {
+            author: metadata.author,
+            tags: metadata.tags,
+            importedFromFile: fileName,
+            legacyReadTime: metadata.readTime || calculateReadTime(body),
+          },
+        })
+        .returning({ id: articleVersions.id });
+
+      versionId = insertedVersion[0].id;
+      created = true;
+    } else {
+      await tx
+        .update(articleVersions)
+        .set({
+          mdxSource: body,
+          plainTextSnapshot,
+          lineIndex,
+          generationContext: {
+            author: metadata.author,
+            tags: metadata.tags,
+            importedFromFile: fileName,
+            legacyReadTime: metadata.readTime || calculateReadTime(body),
+          },
+        })
+        .where(eq(articleVersions.id, versionId));
+
+      updated = true;
+    }
+
+    await tx
+      .update(articles)
+      .set({
+        currentVersionId: versionId,
+        publishedVersionId: versionId,
+        updatedAt: new Date(),
+      })
+      .where(eq(articles.id, articleId));
+
+    return {
+      slug,
+      created,
+      updated,
+      dryRun: false,
+    };
+  });
+}
+
+async function main() {
+  if (!fs.existsSync(articleDirectory)) {
+    throw new Error(`Legacy article directory not found: ${articleDirectory}`);
+  }
+
+  const files = fs
+    .readdirSync(articleDirectory)
+    .filter((fileName) => fileName.endsWith(".md") || fileName.endsWith(".mdx"))
+    .sort();
+
+  if (files.length === 0) {
+    console.log("No legacy article files found.");
+    return;
+  }
+
+  const results = [];
+
+  for (const fileName of files) {
+    const result = await upsertLegacyPost(fileName);
+    results.push(result);
+    console.log(
+      `[legacy-import] ${result.dryRun ? "DRY RUN" : "SYNC"} ${result.slug} created=${result.created} updated=${result.updated}`
+    );
+  }
+
+  console.log(`[legacy-import] Processed ${results.length} files.`);
+}
+
+main().catch((error) => {
+  console.error("[legacy-import] Failed:", error);
+  process.exit(1);
+});

--- a/scripts/import-legacy-posts.ts
+++ b/scripts/import-legacy-posts.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import fs from "node:fs";
 import path from "node:path";
 import { and, desc, eq } from "drizzle-orm";

--- a/services/articleRepository.ts
+++ b/services/articleRepository.ts
@@ -1,0 +1,77 @@
+import { and, desc, eq } from "drizzle-orm";
+import { getDb } from "@/db/client";
+import { articleVersions, articles } from "@/db/schema";
+import { hasDatabaseUrl } from "@/lib/env";
+import { calculateReadTime } from "@/lib/content/posts";
+import { BlogPost } from "@/types";
+
+function mapPublishedArticleToBlogPost(row: {
+  article: typeof articles.$inferSelect;
+  version: typeof articleVersions.$inferSelect;
+}): BlogPost {
+  const { article, version } = row;
+
+  return {
+    slug: article.slug,
+    title: article.title,
+    summary: article.summary,
+    content: version.mdxSource,
+    author: "Jeanne",
+    date: article.publishedAt
+      ? article.publishedAt.toISOString().split("T")[0]
+      : article.updatedAt.toISOString().split("T")[0],
+    tags:
+      typeof version.generationContext?.tags === "object" &&
+      Array.isArray(version.generationContext.tags)
+        ? version.generationContext.tags.filter(
+            (tag): tag is string => typeof tag === "string"
+          )
+        : ["General"],
+    readTime: calculateReadTime(version.plainTextSnapshot || version.mdxSource),
+    contentSource: "database",
+  };
+}
+
+export async function getPublishedPostsFromDatabase(): Promise<BlogPost[]> {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      article: articles,
+      version: articleVersions,
+    })
+    .from(articles)
+    .innerJoin(articleVersions, eq(articles.publishedVersionId, articleVersions.id))
+    .where(eq(articles.status, "published"))
+    .orderBy(desc(articles.publishedAt), desc(articles.updatedAt));
+
+  return rows.map(mapPublishedArticleToBlogPost);
+}
+
+export async function getPublishedPostBySlugFromDatabase(
+  slug: string
+): Promise<BlogPost | null> {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  const db = getDb();
+  const row = await db
+    .select({
+      article: articles,
+      version: articleVersions,
+    })
+    .from(articles)
+    .innerJoin(articleVersions, eq(articles.publishedVersionId, articleVersions.id))
+    .where(and(eq(articles.status, "published"), eq(articles.slug, slug)))
+    .limit(1);
+
+  if (row.length === 0) {
+    return null;
+  }
+
+  return mapPublishedArticleToBlogPost(row[0]);
+}

--- a/services/articleRepository.ts
+++ b/services/articleRepository.ts
@@ -10,13 +10,17 @@ function mapPublishedArticleToBlogPost(row: {
   version: typeof articleVersions.$inferSelect;
 }): BlogPost {
   const { article, version } = row;
+  const author =
+    typeof version.generationContext?.author === "string"
+      ? version.generationContext.author
+      : "Jeanne";
 
   return {
     slug: article.slug,
     title: article.title,
     summary: article.summary,
     content: version.mdxSource,
-    author: "Jeanne",
+    author,
     date: article.publishedAt
       ? article.publishedAt.toISOString().split("T")[0]
       : article.updatedAt.toISOString().split("T")[0],

--- a/services/commentRepository.ts
+++ b/services/commentRepository.ts
@@ -1,0 +1,116 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "@/db/client";
+import { articleVersions, reviewComments } from "@/db/schema";
+import { hasDatabaseUrl } from "@/lib/env";
+import { CreateCommentInput, UpdateCommentInput } from "@/lib/validators/comments";
+import { DraftComment } from "@/types";
+
+function mapComment(comment: typeof reviewComments.$inferSelect): DraftComment {
+  return {
+    id: comment.id,
+    articleVersionId: comment.articleVersionId,
+    startLine: comment.startLine,
+    endLine: comment.endLine,
+    selectedText: comment.selectedText,
+    body: comment.body,
+    status: comment.status,
+    createdAt: comment.createdAt.toISOString(),
+    updatedAt: comment.updatedAt.toISOString(),
+  };
+}
+
+export async function createComment(input: CreateCommentInput): Promise<DraftComment> {
+  if (!hasDatabaseUrl()) {
+    throw new Error("Database is not configured.");
+  }
+
+  if (input.endLine < input.startLine) {
+    throw new Error("endLine must be greater than or equal to startLine.");
+  }
+
+  const db = getDb();
+  const versionRows = await db
+    .select({
+      id: articleVersions.id,
+      lineIndex: articleVersions.lineIndex,
+    })
+    .from(articleVersions)
+    .where(eq(articleVersions.id, input.articleVersionId))
+    .limit(1);
+
+  if (versionRows.length === 0) {
+    throw new Error("Article version not found.");
+  }
+
+  const maxLineNumber = versionRows[0].lineIndex.length;
+  if (input.startLine > maxLineNumber || input.endLine > maxLineNumber) {
+    throw new Error("Comment range exceeds available lines.");
+  }
+
+  const inserted = await db
+    .insert(reviewComments)
+    .values({
+      articleVersionId: input.articleVersionId,
+      startLine: input.startLine,
+      endLine: input.endLine,
+      selectedText: input.selectedText,
+      body: input.body,
+    })
+    .returning();
+
+  return mapComment(inserted[0]);
+}
+
+export async function updateComment(
+  id: string,
+  input: UpdateCommentInput
+): Promise<DraftComment | null> {
+  if (!hasDatabaseUrl()) {
+    throw new Error("Database is not configured.");
+  }
+
+  const db = getDb();
+  const updated = await db
+    .update(reviewComments)
+    .set({
+      ...(input.body ? { body: input.body } : {}),
+      ...(input.status ? { status: input.status } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(reviewComments.id, id))
+    .returning();
+
+  if (updated.length === 0) {
+    return null;
+  }
+
+  return mapComment(updated[0]);
+}
+
+export async function deleteComment(id: string): Promise<boolean> {
+  if (!hasDatabaseUrl()) {
+    throw new Error("Database is not configured.");
+  }
+
+  const db = getDb();
+  const deleted = await db.delete(reviewComments).where(eq(reviewComments.id, id)).returning({
+    id: reviewComments.id,
+  });
+
+  return deleted.length > 0;
+}
+
+export async function getCommentsByVersionId(articleVersionId: string): Promise<DraftComment[]> {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  const db = getDb();
+  const comments = await db
+    .select()
+    .from(reviewComments)
+    .where(eq(reviewComments.articleVersionId, articleVersionId))
+    .orderBy(reviewComments.startLine, reviewComments.createdAt);
+
+  return comments.map(mapComment);
+}

--- a/services/draftRepository.ts
+++ b/services/draftRepository.ts
@@ -1,0 +1,56 @@
+import { and, desc, eq } from "drizzle-orm";
+import { getDb } from "@/db/client";
+import { articleVersions, articles, reviewComments } from "@/db/schema";
+import { hasDatabaseUrl } from "@/lib/env";
+import { DraftSummary } from "@/types";
+
+export async function getDraftSummaries(): Promise<DraftSummary[]> {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      article: articles,
+      version: articleVersions,
+    })
+    .from(articles)
+    .leftJoin(articleVersions, eq(articles.currentVersionId, articleVersions.id))
+    .orderBy(desc(articles.updatedAt));
+
+  const draftSummaries = await Promise.all(
+    rows.map(async ({ article, version }) => {
+      let openCommentCount = 0;
+
+      if (version?.id) {
+        const commentRows = await db
+          .select({
+            id: reviewComments.id,
+          })
+          .from(reviewComments)
+          .where(
+            and(
+              eq(reviewComments.articleVersionId, version.id),
+              eq(reviewComments.status, "open")
+            )
+          );
+
+        openCommentCount = commentRows.length;
+      }
+
+      return {
+        id: article.id,
+        slug: article.slug,
+        title: article.title,
+        summary: article.summary,
+        status: article.status,
+        versionNumber: version?.versionNumber ?? null,
+        openCommentCount,
+        updatedAt: article.updatedAt.toISOString(),
+      } satisfies DraftSummary;
+    })
+  );
+
+  return draftSummaries;
+}

--- a/services/draftRepository.ts
+++ b/services/draftRepository.ts
@@ -2,7 +2,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { getDb } from "@/db/client";
 import { articleVersions, articles, reviewComments } from "@/db/schema";
 import { hasDatabaseUrl } from "@/lib/env";
-import { DraftSummary } from "@/types";
+import { DraftDetail, DraftSummary } from "@/types";
 
 export async function getDraftSummaries(): Promise<DraftSummary[]> {
   if (!hasDatabaseUrl()) {
@@ -53,4 +53,73 @@ export async function getDraftSummaries(): Promise<DraftSummary[]> {
   );
 
   return draftSummaries;
+}
+
+export async function getDraftDetailById(id: string): Promise<DraftDetail | null> {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({
+      article: articles,
+      version: articleVersions,
+    })
+    .from(articles)
+    .leftJoin(articleVersions, eq(articles.currentVersionId, articleVersions.id))
+    .where(eq(articles.id, id))
+    .limit(1);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const { article, version } = rows[0];
+
+  const versions = await db
+    .select()
+    .from(articleVersions)
+    .where(eq(articleVersions.articleId, article.id))
+    .orderBy(desc(articleVersions.versionNumber));
+
+  const comments = version?.id
+    ? await db
+        .select()
+        .from(reviewComments)
+        .where(eq(reviewComments.articleVersionId, version.id))
+        .orderBy(reviewComments.startLine, reviewComments.createdAt)
+    : [];
+
+  return {
+    id: article.id,
+    slug: article.slug,
+    title: article.title,
+    summary: article.summary,
+    status: article.status,
+    updatedAt: article.updatedAt.toISOString(),
+    currentVersionId: version?.id ?? null,
+    currentVersionNumber: version?.versionNumber ?? null,
+    content: version?.mdxSource ?? "",
+    lineIndex: version?.lineIndex ?? [],
+    versions: versions.map((item) => ({
+      id: item.id,
+      versionNumber: item.versionNumber,
+      sourceType: item.sourceType,
+      sourceLabel: item.sourceLabel,
+      modelName: item.modelName,
+      createdAt: item.createdAt.toISOString(),
+    })),
+    comments: comments.map((comment) => ({
+      id: comment.id,
+      articleVersionId: comment.articleVersionId,
+      startLine: comment.startLine,
+      endLine: comment.endLine,
+      selectedText: comment.selectedText,
+      body: comment.body,
+      status: comment.status,
+      createdAt: comment.createdAt.toISOString(),
+      updatedAt: comment.updatedAt.toISOString(),
+    })),
+  } satisfies DraftDetail;
 }

--- a/services/postService.ts
+++ b/services/postService.ts
@@ -1,52 +1,15 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import { parsePostFile, calculateReadTime } from '@/lib/content/posts';
+import {
+  getPublishedPostBySlugFromDatabase,
+  getPublishedPostsFromDatabase,
+} from '@/services/articleRepository';
 import { BlogPost, AboutData } from '../types';
 
 const contentDirectory = path.join(process.cwd(), 'contents', 'article');
 const pagesDirectory = path.join(process.cwd(), 'contents', 'about');
-
-// Helper to parse YAML Frontmatter
-const parseFrontmatter = (content: string) => {
-  const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
-  const match = content.match(frontmatterRegex);
-
-  if (!match) {
-    return { metadata: {}, body: content };
-  }
-
-  const frontmatterBlock = match[1];
-  const body = content.replace(frontmatterRegex, '').trim();
-
-  const metadata: any = {};
-  frontmatterBlock.split('\n').forEach(line => {
-    const [key, ...valueParts] = line.split(':');
-    if (key && valueParts.length > 0) {
-      let value = valueParts.join(':').trim();
-      
-      // Clean quotes
-      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'" ) && value.endsWith("'"))) {
-        value = value.slice(1, -1);
-      }
-      
-      // Handle arrays
-      if (value.startsWith('[') && value.endsWith(']')) {
-        metadata[key.trim()] = value.slice(1, -1).split(',').map(v => v.trim());
-      } else {
-        metadata[key.trim()] = value;
-      }
-    }
-  });
-
-  return { metadata, body };
-};
-
-const calculateReadTime = (text: string): string => {
-  const wpm = 200;
-  const words = text.trim().split(/\s+/).length;
-  const time = Math.ceil(words / wpm);
-  return `${time} min read`;
-};
 
 export async function getAboutContent(): Promise<AboutData | null> {
   const slug = 'about';
@@ -82,6 +45,15 @@ export async function getAboutContent(): Promise<AboutData | null> {
 }
 
 export async function getAllPosts(): Promise<BlogPost[]> {
+  try {
+    const databasePosts = await getPublishedPostsFromDatabase();
+    if (databasePosts.length > 0) {
+      return databasePosts;
+    }
+  } catch (error) {
+    console.warn('Failed to load posts from database, falling back to filesystem.', error);
+  }
+
   if (!fs.existsSync(contentDirectory)) {
     fs.mkdirSync(contentDirectory, { recursive: true });
     return [];
@@ -94,7 +66,7 @@ export async function getAllPosts(): Promise<BlogPost[]> {
       const slug = fileName.replace(/\.mdx?$/, '');
       const fullPath = path.join(contentDirectory, fileName);
       const fileContents = fs.readFileSync(fullPath, 'utf8');
-      const { metadata, body } = parseFrontmatter(fileContents);
+      const { metadata, body } = parsePostFile(fileContents);
 
       return {
         slug,
@@ -105,6 +77,7 @@ export async function getAllPosts(): Promise<BlogPost[]> {
         date: metadata.date || new Date().toISOString().split('T')[0],
         tags: metadata.tags || ['General'],
         readTime: metadata.readTime || calculateReadTime(body),
+        contentSource: 'filesystem',
       } as BlogPost;
     });
 
@@ -114,6 +87,15 @@ export async function getAllPosts(): Promise<BlogPost[]> {
 }
 
 export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
+  try {
+    const databasePost = await getPublishedPostBySlugFromDatabase(slug);
+    if (databasePost) {
+      return databasePost;
+    }
+  } catch (error) {
+    console.warn(`Failed to load post ${slug} from database, falling back to filesystem.`, error);
+  }
+
   const fullPathMd = path.join(contentDirectory, `${slug}.md`);
   const fullPathMdx = path.join(contentDirectory, `${slug}.mdx`);
   
@@ -127,7 +109,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
   }
 
   const fileContents = fs.readFileSync(fullPath, 'utf8');
-  const { metadata, body } = parseFrontmatter(fileContents);
+  const { metadata, body } = parsePostFile(fileContents);
 
   return {
     slug,
@@ -138,5 +120,6 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
     date: metadata.date || new Date().toISOString().split('T')[0],
     tags: metadata.tags || ['General'],
     readTime: metadata.readTime || calculateReadTime(body),
+    contentSource: 'filesystem',
   } as BlogPost;
 }

--- a/services/regenerationJobRepository.ts
+++ b/services/regenerationJobRepository.ts
@@ -1,7 +1,18 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import { getDb } from "@/db/client";
 import { articleVersions, articles, regenerationJobs, reviewComments } from "@/db/schema";
 import { hasDatabaseUrl } from "@/lib/env";
+import {
+  buildLineIndex,
+  calculateReadTime,
+  createPlainTextSnapshot,
+} from "@/lib/content/posts";
+import {
+  CompleteRegenerationJobInput,
+  FailRegenerationJobInput,
+} from "@/lib/validators/internal-jobs";
+
+const JOB_STALE_AFTER_MS = 15 * 60 * 1000;
 
 export async function createRegenerationJob(articleId: string) {
   if (!hasDatabaseUrl()) {
@@ -110,5 +121,238 @@ export async function createRegenerationJob(articleId: string) {
       .where(eq(articles.id, articleId));
 
     return inserted[0];
+  });
+}
+
+export async function claimNextRegenerationJob(workerId: string) {
+  if (!hasDatabaseUrl()) {
+    throw new Error("Database is not configured.");
+  }
+
+  if (!workerId) {
+    throw new Error("workerId is required.");
+  }
+
+  const db = getDb();
+  const staleBefore = new Date(Date.now() - JOB_STALE_AFTER_MS);
+
+  return db.transaction(async (tx) => {
+    const queuedJobs = await tx
+      .select()
+      .from(regenerationJobs)
+      .where(
+        and(eq(regenerationJobs.jobType, "regenerate"), eq(regenerationJobs.status, "queued"))
+      )
+      .orderBy(asc(regenerationJobs.createdAt))
+      .limit(1);
+
+    const staleRunningJobs = await tx
+      .select()
+      .from(regenerationJobs)
+      .where(
+        and(eq(regenerationJobs.jobType, "regenerate"), eq(regenerationJobs.status, "running"))
+      )
+      .orderBy(asc(regenerationJobs.createdAt))
+      .limit(20);
+
+    const claimableJob =
+      queuedJobs[0] ??
+      staleRunningJobs.find((job) => job.lockedAt && job.lockedAt <= staleBefore);
+
+    if (!claimableJob) {
+      return null;
+    }
+
+    const updated = await tx
+      .update(regenerationJobs)
+      .set({
+        status: "running",
+        lockedAt: new Date(),
+        workerId,
+        updatedAt: new Date(),
+        attemptCount: claimableJob.status === "running" ? claimableJob.attemptCount + 1 : claimableJob.attemptCount,
+      })
+      .where(
+        and(
+          eq(regenerationJobs.id, claimableJob.id),
+          claimableJob.status === "queued"
+            ? eq(regenerationJobs.status, "queued")
+            : eq(regenerationJobs.status, "running")
+        )
+      )
+      .returning();
+
+    if (updated.length === 0) {
+      return null;
+    }
+
+    return updated[0];
+  });
+}
+
+export async function completeRegenerationJob(
+  jobId: string,
+  workerId: string,
+  input: CompleteRegenerationJobInput
+) {
+  if (!hasDatabaseUrl()) {
+    throw new Error("Database is not configured.");
+  }
+
+  const db = getDb();
+  const now = new Date();
+  const plainTextSnapshot = createPlainTextSnapshot(input.mdxSource);
+  const lineIndex = buildLineIndex(input.mdxSource);
+  const readTime = calculateReadTime(plainTextSnapshot);
+
+  return db.transaction(async (tx) => {
+    const jobRows = await tx
+      .select()
+      .from(regenerationJobs)
+      .where(eq(regenerationJobs.id, jobId))
+      .limit(1);
+
+    if (jobRows.length === 0) {
+      throw new Error("Regeneration job not found.");
+    }
+
+    const job = jobRows[0];
+
+    if (job.status !== "running") {
+      throw new Error("Regeneration job is not running.");
+    }
+
+    if (job.workerId && job.workerId !== workerId) {
+      throw new Error("Regeneration job is locked by another worker.");
+    }
+
+    const articleRows = await tx
+      .select()
+      .from(articles)
+      .where(eq(articles.id, job.articleId))
+      .limit(1);
+
+    if (articleRows.length === 0) {
+      throw new Error("Draft not found.");
+    }
+
+    const article = articleRows[0];
+    const latestVersion = await tx
+      .select({
+        versionNumber: articleVersions.versionNumber,
+      })
+      .from(articleVersions)
+      .where(eq(articleVersions.articleId, article.id))
+      .orderBy(desc(articleVersions.versionNumber))
+      .limit(1);
+
+    const nextVersionNumber = (latestVersion[0]?.versionNumber ?? 0) + 1;
+
+    const insertedVersion = await tx
+      .insert(articleVersions)
+      .values({
+        articleId: article.id,
+        versionNumber: nextVersionNumber,
+        sourceType: "regenerated",
+        sourceLabel: `regeneration-job:${job.id}`,
+        mdxSource: input.mdxSource,
+        plainTextSnapshot,
+        lineIndex,
+        generationPromptSnapshot: input.generationPromptSnapshot,
+        generationContext: {
+          ...input.generationContext,
+          author: input.author ?? "Jeanne",
+          tags: input.tags ?? [],
+          readTime,
+          regenerationJobId: job.id,
+          baseVersionId: job.baseVersionId,
+        },
+        modelName: input.modelName,
+      })
+      .returning({
+        id: articleVersions.id,
+      });
+
+    await tx
+      .update(articles)
+      .set({
+        title: input.title,
+        summary: input.summary,
+        currentVersionId: insertedVersion[0].id,
+        status: "draft",
+        updatedAt: now,
+      })
+      .where(eq(articles.id, article.id));
+
+    const completedJob = await tx
+      .update(regenerationJobs)
+      .set({
+        status: "completed",
+        resultVersionId: insertedVersion[0].id,
+        updatedAt: now,
+        lockedAt: now,
+        workerId,
+        errorMessage: null,
+      })
+      .where(eq(regenerationJobs.id, job.id))
+      .returning();
+
+    return completedJob[0];
+  });
+}
+
+export async function failRegenerationJob(
+  jobId: string,
+  workerId: string,
+  input: FailRegenerationJobInput
+) {
+  if (!hasDatabaseUrl()) {
+    throw new Error("Database is not configured.");
+  }
+
+  const db = getDb();
+
+  return db.transaction(async (tx) => {
+    const jobRows = await tx
+      .select()
+      .from(regenerationJobs)
+      .where(eq(regenerationJobs.id, jobId))
+      .limit(1);
+
+    if (jobRows.length === 0) {
+      throw new Error("Regeneration job not found.");
+    }
+
+    const job = jobRows[0];
+
+    if (job.status !== "running") {
+      throw new Error("Regeneration job is not running.");
+    }
+
+    if (job.workerId && job.workerId !== workerId) {
+      throw new Error("Regeneration job is locked by another worker.");
+    }
+
+    const failedJob = await tx
+      .update(regenerationJobs)
+      .set({
+        status: "failed",
+        errorMessage: input.errorMessage,
+        updatedAt: new Date(),
+        lockedAt: new Date(),
+        workerId,
+      })
+      .where(eq(regenerationJobs.id, jobId))
+      .returning();
+
+    await tx
+      .update(articles)
+      .set({
+        status: "draft",
+        updatedAt: new Date(),
+      })
+      .where(eq(articles.id, job.articleId));
+
+    return failedJob[0];
   });
 }

--- a/services/regenerationJobRepository.ts
+++ b/services/regenerationJobRepository.ts
@@ -1,0 +1,114 @@
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { getDb } from "@/db/client";
+import { articleVersions, articles, regenerationJobs, reviewComments } from "@/db/schema";
+import { hasDatabaseUrl } from "@/lib/env";
+
+export async function createRegenerationJob(articleId: string) {
+  if (!hasDatabaseUrl()) {
+    throw new Error("Database is not configured.");
+  }
+
+  const db = getDb();
+
+  return db.transaction(async (tx) => {
+    const articleRows = await tx
+      .select()
+      .from(articles)
+      .where(eq(articles.id, articleId))
+      .limit(1);
+
+    if (articleRows.length === 0) {
+      throw new Error("Draft not found.");
+    }
+
+    const article = articleRows[0];
+
+    if (!article.currentVersionId) {
+      throw new Error("Draft has no current version.");
+    }
+
+    const existingJobs = await tx
+      .select()
+      .from(regenerationJobs)
+      .where(
+        and(
+          eq(regenerationJobs.articleId, articleId),
+          inArray(regenerationJobs.status, ["queued", "running"])
+        )
+      )
+      .orderBy(desc(regenerationJobs.createdAt))
+      .limit(1);
+
+    if (existingJobs.length > 0) {
+      throw new Error("A regeneration job is already queued or running for this draft.");
+    }
+
+    const versionRows = await tx
+      .select()
+      .from(articleVersions)
+      .where(eq(articleVersions.id, article.currentVersionId))
+      .limit(1);
+
+    if (versionRows.length === 0) {
+      throw new Error("Current draft version not found.");
+    }
+
+    const currentVersion = versionRows[0];
+    const openComments = await tx
+      .select()
+      .from(reviewComments)
+      .where(
+        and(
+          eq(reviewComments.articleVersionId, currentVersion.id),
+          eq(reviewComments.status, "open")
+        )
+      )
+      .orderBy(reviewComments.startLine, reviewComments.createdAt);
+
+    const inserted = await tx
+      .insert(regenerationJobs)
+      .values({
+        articleId,
+        baseVersionId: currentVersion.id,
+        status: "queued",
+        jobType: "regenerate",
+        inputPayload: {
+          article: {
+            id: article.id,
+            slug: article.slug,
+            title: article.title,
+            summary: article.summary,
+          },
+          baseVersion: {
+            id: currentVersion.id,
+            versionNumber: currentVersion.versionNumber,
+            sourceType: currentVersion.sourceType,
+            mdxSource: currentVersion.mdxSource,
+            generationContext: currentVersion.generationContext,
+            modelName: currentVersion.modelName,
+          },
+          comments: openComments.map((comment) => ({
+            id: comment.id,
+            startLine: comment.startLine,
+            endLine: comment.endLine,
+            selectedText: comment.selectedText,
+            body: comment.body,
+          })),
+        },
+      })
+      .returning({
+        id: regenerationJobs.id,
+        status: regenerationJobs.status,
+      });
+
+    await tx
+      .update(articles)
+      .set({
+        status: "regenerating",
+        updatedAt: new Date(),
+      })
+      .where(eq(articles.id, articleId));
+
+    return inserted[0];
+  });
+}

--- a/types.ts
+++ b/types.ts
@@ -22,6 +22,47 @@ export interface DraftSummary {
   updatedAt: string;
 }
 
+export interface DraftVersionSummary {
+  id: string;
+  versionNumber: number;
+  sourceType: 'weekly' | 'project' | 'manual' | 'regenerated';
+  sourceLabel?: string | null;
+  modelName?: string | null;
+  createdAt: string;
+}
+
+export interface DraftComment {
+  id: string;
+  articleVersionId: string;
+  startLine: number;
+  endLine: number;
+  selectedText: string;
+  body: string;
+  status: 'open' | 'resolved' | 'dismissed';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DraftDetail {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  status: 'draft' | 'in_review' | 'regenerating' | 'published' | 'archived';
+  updatedAt: string;
+  currentVersionId: string | null;
+  currentVersionNumber: number | null;
+  content: string;
+  lineIndex: Array<{
+    lineNumber: number;
+    startOffset: number;
+    endOffset: number;
+    content: string;
+  }>;
+  versions: DraftVersionSummary[];
+  comments: DraftComment[];
+}
+
 export enum PageView {
   HOME,
   POST_DETAIL,

--- a/types.ts
+++ b/types.ts
@@ -11,6 +11,17 @@ export interface BlogPost {
   contentSource?: 'database' | 'filesystem';
 }
 
+export interface DraftSummary {
+  id: string;
+  slug: string;
+  title: string;
+  summary: string;
+  status: 'draft' | 'in_review' | 'regenerating' | 'published' | 'archived';
+  versionNumber: number | null;
+  openCommentCount: number;
+  updatedAt: string;
+}
+
 export enum PageView {
   HOME,
   POST_DETAIL,

--- a/types.ts
+++ b/types.ts
@@ -8,6 +8,7 @@ export interface BlogPost {
   tags: string[];
   readTime: string;
   coverImage?: string;
+  contentSource?: 'database' | 'filesystem';
 }
 
 export enum PageView {


### PR DESCRIPTION
## Summary
- migrate blog content to Supabase-backed Postgres with Drizzle
- add private studio flows for draft review, manual editing, comments, and regeneration requests
- add internal APIs for pipeline draft ingest and regeneration worker callbacks

## Verification
- npx tsc --noEmit
- npm run build
- npm run db:push
- npm run db:import:legacy
