### PR TITLE
fix: prevent accidental published imports and stale post pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import { getAllPosts } from '../services/postService';
 import { PostList } from '../components/PostList';
 
-export const revalidate = 3600;
+export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const posts = await getAllPosts();

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,7 +1,9 @@
-import { getPostBySlug, getAllPosts } from '../../../services/postService';
+import { getPostBySlug } from '../../../services/postService';
 import { PostDetail } from '../../../components/PostDetail';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -29,13 +31,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       tags: post.tags,
     },
   };
-}
-
-export async function generateStaticParams() {
-  const posts = await getAllPosts();
-  return posts.map((post) => ({
-    slug: post.slug,
-  }));
 }
 
 export default async function BlogPostPage({ params }: Props) {

--- a/lib/content/posts.ts
+++ b/lib/content/posts.ts
@@ -10,6 +10,18 @@ type ParsedPostMetadata = {
   readTime?: string;
 };
 
+function normalizeFrontmatterDate(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString().split("T")[0];
+  }
+
+  return new Date().toISOString().split("T")[0];
+}
+
 export function parsePostFile(fileContents: string): {
   metadata: ParsedPostMetadata;
   body: string;
@@ -21,10 +33,7 @@ export function parsePostFile(fileContents: string): {
       title: typeof data.title === "string" ? data.title : "",
       summary: typeof data.summary === "string" ? data.summary : "",
       author: typeof data.author === "string" ? data.author : "Admin",
-      date:
-        typeof data.date === "string"
-          ? data.date
-          : new Date().toISOString().split("T")[0],
+      date: normalizeFrontmatterDate(data.date),
       tags: Array.isArray(data.tags)
         ? data.tags.filter((tag): tag is string => typeof tag === "string")
         : ["General"],

--- a/scripts/import-legacy-posts.ts
+++ b/scripts/import-legacy-posts.ts
@@ -13,6 +13,7 @@ import {
 
 const articleDirectory = path.join(process.cwd(), "contents", "article");
 const dryRun = process.argv.includes("--dry-run");
+const publishImportedPosts = process.argv.includes("--publish");
 
 function toPublishedDate(dateValue: string) {
   const parsed = new Date(dateValue);
@@ -60,10 +61,10 @@ async function upsertLegacyPost(fileName: string) {
         .insert(articles)
         .values({
           slug,
-          status: "published",
+          status: publishImportedPosts ? "published" : "draft",
           title: metadata.title || slug,
           summary,
-          publishedAt,
+          publishedAt: publishImportedPosts ? publishedAt : null,
           createdAt: publishedAt,
           updatedAt: new Date(),
         })
@@ -72,16 +73,18 @@ async function upsertLegacyPost(fileName: string) {
       articleId = insertedArticle[0].id;
       created = true;
     } else {
-      await tx
-        .update(articles)
-        .set({
-          status: "published",
-          title: metadata.title || slug,
-          summary,
-          publishedAt,
-          updatedAt: new Date(),
-        })
-        .where(eq(articles.id, articleId));
+      const articleUpdate: Partial<typeof articles.$inferInsert> = {
+        title: metadata.title || slug,
+        summary,
+        updatedAt: new Date(),
+      };
+
+      if (publishImportedPosts) {
+        articleUpdate.status = "published";
+        articleUpdate.publishedAt = publishedAt;
+      }
+
+      await tx.update(articles).set(articleUpdate).where(eq(articles.id, articleId));
 
       updated = true;
     }
@@ -146,14 +149,16 @@ async function upsertLegacyPost(fileName: string) {
       updated = true;
     }
 
-    await tx
-      .update(articles)
-      .set({
-        currentVersionId: versionId,
-        publishedVersionId: versionId,
-        updatedAt: new Date(),
-      })
-      .where(eq(articles.id, articleId));
+    const versionPointers: Partial<typeof articles.$inferInsert> = {
+      currentVersionId: versionId,
+      updatedAt: new Date(),
+    };
+
+    if (publishImportedPosts) {
+      versionPointers.publishedVersionId = versionId;
+    }
+
+    await tx.update(articles).set(versionPointers).where(eq(articles.id, articleId));
 
     return {
       slug,
@@ -185,11 +190,13 @@ async function main() {
     const result = await upsertLegacyPost(fileName);
     results.push(result);
     console.log(
-      `[legacy-import] ${result.dryRun ? "DRY RUN" : "SYNC"} ${result.slug} created=${result.created} updated=${result.updated}`
+      `[legacy-import] ${result.dryRun ? "DRY RUN" : publishImportedPosts ? "PUBLISH" : "IMPORT"} ${result.slug} created=${result.created} updated=${result.updated}`
     );
   }
 
-  console.log(`[legacy-import] Processed ${results.length} files.`);
+  console.log(
+    `[legacy-import] Processed ${results.length} files. publishImportedPosts=${publishImportedPosts}`
+  );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- make legacy article import safe by default and only publish on explicit --publish
- handle frontmatter dates parsed as Date objects correctly during import
- render the post list and post detail pages dynamically so DB publication changes reflect immediately

## Validation
- npx tsc --noEmit
- production DB correction applied for the two accidental posts and two incorrect dates