### PR TITLE
fix: render studio routes dynamically

### DIFF
--- a/app/studio/drafts/[id]/page.tsx
+++ b/app/studio/drafts/[id]/page.tsx
@@ -6,6 +6,8 @@ import { RegenerateDraftButton } from "@/components/studio/RegenerateDraftButton
 import { StudioLogoutButton } from "@/components/studio/StudioLogoutButton";
 import { getDraftDetailById } from "@/services/draftRepository";
 
+export const dynamic = "force-dynamic";
+
 const statusStyles: Record<string, string> = {
   draft: "bg-amber-100 text-amber-900",
   in_review: "bg-blue-100 text-blue-900",

--- a/app/studio/drafts/page.tsx
+++ b/app/studio/drafts/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { StudioLogoutButton } from "@/components/studio/StudioLogoutButton";
 import { getDraftSummaries } from "@/services/draftRepository";
 
+export const dynamic = "force-dynamic";
+
 const statusStyles: Record<string, string> = {
   draft: "bg-amber-100 text-amber-900",
   in_review: "bg-blue-100 text-blue-900",

--- a/app/studio/login/page.tsx
+++ b/app/studio/login/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import { isAdminSessionAuthenticated } from "@/lib/auth/admin-session";
 import { StudioLoginForm } from "@/components/studio/StudioLoginForm";
 
+export const dynamic = "force-dynamic";
+
 export default async function StudioLoginPage() {
   const isAuthenticated = await isAdminSessionAuthenticated();
 

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { isAdminSessionAuthenticated } from "@/lib/auth/admin-session";
 
+export const dynamic = "force-dynamic";
+
 export default async function StudioPage() {
   const isAuthenticated = await isAdminSessionAuthenticated();
 


### PR DESCRIPTION
## Summary
- render studio routes dynamically
- prevent Next from prerendering DB-backed admin pages during production builds

## Routes
- /studio
- /studio/login
- /studio/drafts
- /studio/drafts/[id]

## Validation
- npx tsc --noEmit